### PR TITLE
support icinga2_objects var outside of hostvars 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       # max-parallel: 4
       matrix:
         distro: [centos7, centos8, debian10]
-        python: ['3.6', '3.8']
+        python: ['3.8','3.10']
         ansible: ['2.9.10']
         scenario: [default]
 
@@ -63,7 +63,7 @@ jobs:
       # max-parallel: 4
       matrix:
         distro: [centos7, centos8, debian10]
-        python: ['3.6', '3.8', '3.9']
+        python: ['3.8', '3.9', '3.10']
         ansible: ['2.10.7', '2.11.8']
         scenario: [default]
 

--- a/molecule/default/host_vars/icinga-default.yaml
+++ b/molecule/default/host_vars/icinga-default.yaml
@@ -1,6 +1,6 @@
 icinga2_custom_config:
   - name: icinga2_command
-    path: zones.d/main/commands/custom_commands.conf 
+    path: zones.d/main/commands/custom_commands.conf
 
 
 icinga2_objects:

--- a/roles/icinga2/tasks/objects.yml
+++ b/roles/icinga2/tasks/objects.yml
@@ -6,6 +6,11 @@
   with_items: "{{ groups['all'] }}"
   when: hostvars[item]['icinga2_objects'][ansible_fqdn] is defined
 
+- name: collect all config objects in play vars
+  set_fact:
+    tmp_objects: "{{ tmp_objects| default([]) + vars['icinga2_objects'][ansible_fqdn] }}"
+  when: vars['icinga2_objects'][ansible_fqdn] is defined
+
 - icinga2_object:
     args: "{{ item }}"
   with_items: "{{ tmp_objects }}"


### PR DESCRIPTION
icinga2_objects are currently only used when defined at hostvars. This is not always useable and confuses many people. 

