### PR TITLE
Added install_on_OSMC using the Debian code by adding symlinks

### DIFF
--- a/roles/icinga2/tasks/features/idomysql/install_on_OSMC.yml
+++ b/roles/icinga2/tasks/features/idomysql/install_on_OSMC.yml
@@ -1,0 +1,1 @@
+install_on_Debian.yml

--- a/roles/icinga2/tasks/features/idopgsql/install_on_OSMC.yml
+++ b/roles/icinga2/tasks/features/idopgsql/install_on_OSMC.yml
@@ -1,0 +1,1 @@
+install_on_Debian.yml

--- a/roles/icinga2/tasks/install_on_OSMC.yml
+++ b/roles/icinga2/tasks/install_on_OSMC.yml
@@ -1,0 +1,1 @@
+install_on_Debian.yml

--- a/roles/icinga2/vars/OSMC.yml
+++ b/roles/icinga2/vars/OSMC.yml
@@ -1,0 +1,1 @@
+Debian.yml

--- a/roles/repos/tasks/OSMC.yml
+++ b/roles/repos/tasks/OSMC.yml
@@ -1,0 +1,1 @@
+Debian.yml


### PR DESCRIPTION
I do have some Rasperry Pis running OSMC which is a derivative of Debian running Kodi. It identifies as "OSMC" in `ansible_os_family`, so I had to patch your collection to make it work on there, too.

As OSMC is identical to Debian in terms of this collection, I chose to use symlinks to the Debian files.

Note: OSMC also changes something about the $PATH and /usr/sbin, so the `icinga2` binary wasn't found by default. I had to add `ansible_become_flags: "--login"` as host variable in the inventory to make it work. (see https://github.com/ansible/ansible/issues/45219#issuecomment-456268428)