### PR TITLE
Fix non-idenpotence during feature disabling

### DIFF
--- a/changelogs/fragments/fix_idempotence_el.yml
+++ b/changelogs/fragments/fix_idempotence_el.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix non-idenpotence during feature disabling

--- a/plugins/action/icinga2_object.py
+++ b/plugins/action/icinga2_object.py
@@ -43,18 +43,18 @@ class ActionModule(ActionBase):
         path = task_vars['icinga2_fragments_path'] + '/' + obj['file'] + '/'
         file_fragment = path + obj['order'] + '_' + object_type.lower() + '-' + obj['name']
 
-        file_args = dict()
-        file_args['state'] = 'directory'
-        file_args['path'] = path
-        file_module = self._execute_module(
-            module_name='file',
-            module_args=file_args,
-            task_vars=task_vars,
-            tmp=tmp
-        )
-        result = merge_hash(result, file_module)
-
         if obj['state'] != 'absent':
+            file_args = dict()
+            file_args['state'] = 'directory'
+            file_args['path'] = path
+            file_module = self._execute_module(
+                module_name='file',
+                module_args=file_args,
+                task_vars=task_vars,
+                tmp=tmp
+            )
+            result = merge_hash(result, file_module)
+
             varlist = list()  # list of variables from 'apply for'
 
             #

--- a/roles/icinga2/tasks/configure.yml
+++ b/roles/icinga2/tasks/configure.yml
@@ -45,8 +45,8 @@
     - item.path not in _icinga2_custom_conf_paths
 
 - name: collect empty config dirs
-  shell: >
-    find {{ icinga2_fragments_path }} -type d -empty
+  shell: >-
+    find {{ icinga2_fragments_path }} -mindepth 1 -type d -empty
   register: _empty_result
   check_mode: false
   changed_when: _empty_result.stdout_lines |length > 0


### PR DESCRIPTION
- icinga_object initial state was directory, which clashed with an initial state: absent since the directories didn't exist yet
- The cleanup for empty config dirs needs to exclude the starting directory

Fixes #126 