### PR TITLE
Remove apt-key task

### DIFF
--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -11,7 +11,7 @@ icinga_repo_yum_epel_url: "http://download.fedoraproject.org/pub/epel/{{ ansible
 icinga_repo_yum_epel_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 icinga_repo_apt_key: "{{ icinga_repo_gpgkey }}"
-icinga_repo_apt_keyring: /etc/apt/keyrings/icinga-archive-keyring.gpg
+icinga_repo_apt_keyring: /etc/apt/keyrings/icinga-archive-keyring.asc
 icinga_repo_apt_stable_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }} main"
 icinga_repo_apt_testing_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-testing main"
 icinga_repo_apt_snapshot_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-snapshot main"

--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -11,9 +11,10 @@ icinga_repo_yum_epel_url: "http://download.fedoraproject.org/pub/epel/{{ ansible
 icinga_repo_yum_epel_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 
 icinga_repo_apt_key: "{{ icinga_repo_gpgkey }}"
-icinga_repo_apt_stable_deb: "deb http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }} main"
-icinga_repo_apt_testing_deb: "deb http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-testing main"
-icinga_repo_apt_snapshot_deb: "deb http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-snapshot main"
+icinga_repo_apt_keyring: /etc/apt/keyrings/icinga-archive-keyring.gpg
+icinga_repo_apt_stable_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }} main"
+icinga_repo_apt_testing_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-testing main"
+icinga_repo_apt_snapshot_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-snapshot main"
 
 icinga_repo_gpgkey: "https://packages.icinga.com/icinga.key"
 icinga_repo_stable: true

--- a/roles/repos/tasks/Debian.yml
+++ b/roles/repos/tasks/Debian.yml
@@ -8,10 +8,14 @@
     mode: '0755'
 
 - name: Apt - add repository key
-  become: yes
-  apt_key:
+  ansible.builtin.get_url:
     url: "{{ icinga_repo_apt_key }}"
-    state: present
+    dest: "{{ icinga_repo_apt_keyring }}"
+    owner: root
+    group: root
+    mode: '0644'
+    force: true
+
 - name: Apt - add Icinga repository (stable)
   become: yes
   apt_repository:

--- a/roles/repos/tasks/Debian.yml
+++ b/roles/repos/tasks/Debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: Apt - ensure apt keyrings directory
+  file:
+    state: directory
+    path: /etc/apt/keyrings
+    owner: root
+    group: root
+    mode: '0755'
+
 - name: Apt - add repository key
   become: yes
   apt_key:


### PR DESCRIPTION
The apt-key tool is deprecated and therefore the keys need to be manually managed. 

It is backwards compatible because you could manage them manually anyways. 

ref #133 