### PR TITLE
Certificate directory missing

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,8 @@ platforms:
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
     pre_build_image: true
 provisioner:

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -162,7 +162,7 @@
         remote_src: yes
       when: icinga2_ca_host == 'none'
 
-- name: use self provided certificates
+- name: Use self generated certificates
   block:
     - set_fact:
         _tmp_crt:
@@ -173,7 +173,15 @@
           - src: "{{ icinga2_ssl_cert }}"
             dest: "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt"
 
-    - name: pre generated certificates copy to icinga2 certs
+    - name: Ensure icinga2 certificate directory
+      file:
+        path: "{{ icinga2_cert_path }}"
+        state: directory
+        owner: "{{ icinga2_user }}"
+        group: "{{ icinga2_group }}"
+        mode: "0750"
+
+    - name: Copy self generated certificates to icinga2 certificate directory
       copy:
         remote_src: no
         src: "{{ _crt.src }}"


### PR DESCRIPTION
When certificates aren't created over Icinga 2 CLI, the certificate directory isn't created by default. 

This PR adds a task to ensure the directory exists with the right permissions. 