### PR TITLE
Change epel task to make use of the 'epel-release' package

### DIFF
--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -10,9 +10,6 @@ icinga_repo_yum_snapshot_url: "http://packages.icinga.com/epel/$releasever/snaps
 icinga_repo_yum_snapshot_key: "{{ icinga_repo_gpgkey }}"
 icinga_repo_yum_snapshot_description: "ICINGA (snapshot release for epel)"
 
-icinga_repo_yum_epel_url: "http://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/$basearch"
-icinga_repo_yum_epel_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
-
 icinga_repo_apt_key: "{{ icinga_repo_gpgkey }}"
 icinga_repo_apt_keyring: /etc/apt/keyrings/icinga-archive-keyring.asc
 icinga_repo_apt_stable_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }} main"

--- a/roles/repos/tasks/RedHat.yml
+++ b/roles/repos/tasks/RedHat.yml
@@ -38,6 +38,7 @@
 - name: Yum - add EPEL repository
   yum:
     name: epel-release
+    state: present
   when: icinga_repo_epel
 
 - name: Yum - add SCL repositories

--- a/roles/repos/tasks/RedHat.yml
+++ b/roles/repos/tasks/RedHat.yml
@@ -36,13 +36,8 @@
     password: "{{ icinga_repo_subscription_password | default(omit) }}"
 
 - name: Yum - add EPEL repository
-  yum_repository:
-    file: /etc/yum.repos.d/epel-release
+  yum:
     name: epel-release
-    enabled: "{{ icinga_repo_epel }}"
-    description: EPEL Release
-    baseurl: "{{ icinga_repo_yum_epel_url }}"
-    gpgkey: "{{ icinga_repo_yum_epel_key }}"
   when: icinga_repo_epel
 
 - name: Yum - add SCL repositories


### PR DESCRIPTION
This is just a minor rewrite of the current epel task.  
Now the `epel-release` package is used instead of 'manually' deploying a \*.repo file.  

This should close #151.