### PR TITLE
Fixes error with importing DB schema twice in HA setups

### DIFF
--- a/roles/icingadb/tasks/manage_schema_mysql.yml
+++ b/roles/icingadb/tasks/manage_schema_mysql.yml
@@ -26,3 +26,4 @@
         {{ mysqlcmd }}
         < {{ icingadb_database_schema }}
       when: db_schema.rc != 0
+      run_once: yes


### PR DESCRIPTION
When managing the DB schema in HA setups (i.e. with two master hosts), the import would be done on each host object, failing for whichever host comes second. `run_once` fixes this.