### PR TITLE
fix psql command

### DIFF
--- a/roles/icinga2/tasks/features/idopgsql.yml
+++ b/roles/icinga2/tasks/features/idopgsql.yml
@@ -25,14 +25,14 @@
         psqlcmd: >-
           PGPASSWORD="{{ icinga2_dict_features.idopgsql.password }}"
           psql
-          host={{ icinga2_dict_features.idopgsql.host| default('localhost') }}
+          "host={{ icinga2_dict_features.idopgsql.host| default('localhost') }}
           port={{ icinga2_dict_features.idopgsql.port| default('5432') }}
           user={{ icinga2_dict_features.idopgsql.user| default('icinga2') }}
           dbname={{ icinga2_dict_features.idopgsql.database |default('icinga2') }}
           {% if icinga2_dict_features.idopgsql.ssl_mode is defined %} sslmode={{ icinga2_dict_features.idopgsql.ssl_mode | default('require') }} {%- endif %}
           {% if icinga2_dict_features.idopgsql.ssl_cert is defined %} sslcert={{ icinga2_dict_features.idopgsql.ssl_cert  }} {%- endif %}
           {% if icinga2_dict_features.idopgsql.ssl_key is defined %} sslkey={{ icinga2_dict_features.idopgsql.ssl_key }} {%- endif %}
-          {% if icinga2_dict_features.idopgsql.extra_options is defined %} {{ icinga2_dict_features.idopgsql.extra_options }} {%- endif %}
+          {% if icinga2_dict_features.idopgsql.extra_options is defined %} {{ icinga2_dict_features.idopgsql.extra_options }} {%- endif %}"
 
     - name: PostgreSQL check for IDO schema
       shell: >


### PR DESCRIPTION
The generated connection string was not working without quotes.

```
fatal: [node-01.icinga.monitoring.test.company.com]: FAILED! => {"changed": true, "cmd": "PGPASSWORD=\"VerySecret\" psql host=postgres-01.icinga.monitoring.test.company.com port=5432 user=icinga dbname=icinga     -w -f /usr/share/icinga2-ido-pgsql/schema/pgsql.sql\n", "delta": "0:00:00.032079", "end": "2023-07-26 14:04:01.266753", "msg": "non-zero return code", "rc": 2, "start": "2023-07-26 14:04:01.234674", "stderr": "psql: warning: extra command-line argument \"user=icinga\" ignored\npsql: warning: extra command-line argument \"dbname=icinga\" ignored\npsql: error: connection to server at \"postgres-01.icinga.monitoring.test.company.com\" (10.202.144.71), port 5432 failed: FATAL:  no pg_hba.conf entry for host \"10.202.144.70\", user \"port=5432\", database \"port=5432\", SSL encryption\nconnection to server at \"postgres-01.icinga.monitoring.test.company.com\" (10.202.144.71), port 5432 failed: FATAL:  no pg_hba.conf entry for host \"10.202.144.70\", user \"port=5432\", database \"port=5432\", no encryption", "stderr_lines": ["psql: warning: extra command-line argument \"user=icinga\" ignored", "psql: warning: extra command-line argument \"dbname=icinga\" ignored", "psql: error: connection to server at \"postgres-01.icinga.monitoring.test.company.com\" (10.202.144.71), port 5432 failed: FATAL:  no pg_hba.conf entry for host \"10.202.144.70\", user \"port=5432\", database \"port=5432\", SSL encryption", "connection to server at \"postgres-01.icinga.monitoring.test.company.com\" (10.202.144.71), port 5432 failed: FATAL:  no pg_hba.conf entry for host \"10.202.144.70\", user \"port=5432\", database \"port=5432\", no encryption"], "stdout": "", "stdout_lines": []}
```