### PR TITLE
Allow IPv6 address to not exist

### DIFF
--- a/changelogs/fragments/trivial_192.yml
+++ b/changelogs/fragments/trivial_192.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Allow IPv6 address to not exist 

--- a/roles/icingadb_redis/defaults/main.yml
+++ b/roles/icingadb_redis/defaults/main.yml
@@ -10,7 +10,7 @@ icingadb_redis_packages:
 icingadb_redis_protected_mode: 'yes'
 icingadb_redis_binds:
   - "127.0.0.1"
-  - "::1"
+  - "-::1"
 icingadb_redis_port: 6380
 icingadb_redis_tcp_backlog: 511
 icingadb_redis_timeout: 0


### PR DESCRIPTION
From the [Redis documentation](https://redis.io/docs/management/config-file/):
By default, if no "bind" configuration directive is specified, Redis listens for connections from all available network interfaces on the host machine.  It is possible to listen to just one or multiple selected interfaces using the "bind" configuration directive, followed by one or more IP addresses.  Each address can be prefixed by "-", which means that redis will not fail to start if the address is not available. Being not available only refers to addresses that does not correspond to any network interface. Addresses that are already in use will always fail, and unsupported protocols will always BE silently skipped.
