### PR TITLE
icingaweb2: Adjust preferences settings to store preferences in database

### DIFF
--- a/changelogs/fragments/bugfixes_icingaweb2_preferences.yml
+++ b/changelogs/fragments/bugfixes_icingaweb2_preferences.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Role Icingaweb2: Adjust preferences setting to store preferences in database

--- a/roles/icingaweb2/defaults/main.yml
+++ b/roles/icingaweb2/defaults/main.yml
@@ -28,7 +28,7 @@ icingaweb2_config:
   global:
     show_stacktraces: 1
     show_application_state_messages: 1
-    config_backend: ini
+    config_resource: icingaweb2_db
     module_path: /usr/share/icingaweb2/modules
   logging:
     log: syslog


### PR DESCRIPTION
According to the changelog of Icinga Web 2 a user was not allowed to set the preferences to be stored in ini format since 2.9 and forced to do the migration in 2.11.
This means this change will make preferences work for current installation of 2.11 and newer and only break versions prior to 2.9, anyone who had this setting in 2.9 or 2.10 has to run the migration described in the changelog and it is very likely it was run already to be compatible.
So I did try to avoid complexity by considering this as bug fix and not a breaking change and trying to avoid it.