### PR TITLE
Adds password capabilities to icingadb-redis configuration

### DIFF
--- a/doc/role-icingadb_redis/role-icingadb_redis.md
+++ b/doc/role-icingadb_redis/role-icingadb_redis.md
@@ -15,7 +15,7 @@ Many variables are predefined by Icinga to make the installation easier. These a
 * `icingadb_redis_port: string`
      * Defines redis server port, default: `6380`
 
-* `icingadb_redis_password: bool|string`
-    * Defaults to `False`, which means no password. Adds the `requirepass <string>` directive to Redis' configuration if set to a string. 
+* `icingadb_redis_password: string`
+    * Adds the `requirepass <string>` directive to Redis' configuration if set.
 
 There is a whole set of `defaults` in place for craeting a sane Redis installation. Should you need to fine-tune settings, please consult [the defaults at `icingadb_redis/defaults/main.yml`](../../roles/icingadb_redis/defaults/main.yml) for the specific variables.

--- a/doc/role-icingadb_redis/role-icingadb_redis.md
+++ b/doc/role-icingadb_redis/role-icingadb_redis.md
@@ -15,4 +15,7 @@ Many variables are predefined by Icinga to make the installation easier. These a
 * `icingadb_redis_port: string`
      * Defines redis server port, default: `6380`
 
+* `icingadb_redis_password: bool|string`
+    * Defaults to `False`, which means no password. Adds the `requirepass <string>` directive to Redis' configuration if set to a string. 
+
 There is a whole set of `defaults` in place for craeting a sane Redis installation. Should you need to fine-tune settings, please consult [the defaults at `icingadb_redis/defaults/main.yml`](../../roles/icingadb_redis/defaults/main.yml) for the specific variables.

--- a/roles/icingadb_redis/defaults/main.yml
+++ b/roles/icingadb_redis/defaults/main.yml
@@ -12,6 +12,7 @@ icingadb_redis_binds:
   - "127.0.0.1"
   - "-::1"
 icingadb_redis_port: 6380
+icingadb_redis_password: False
 icingadb_redis_tcp_backlog: 511
 icingadb_redis_timeout: 0
 icingadb_redis_tcp_keepalive: 300

--- a/roles/icingadb_redis/defaults/main.yml
+++ b/roles/icingadb_redis/defaults/main.yml
@@ -12,7 +12,6 @@ icingadb_redis_binds:
   - "127.0.0.1"
   - "-::1"
 icingadb_redis_port: 6380
-icingadb_redis_password: False
 icingadb_redis_tcp_backlog: 511
 icingadb_redis_timeout: 0
 icingadb_redis_tcp_keepalive: 300

--- a/roles/icingadb_redis/templates/icingadb-redis.conf.j2
+++ b/roles/icingadb_redis/templates/icingadb-redis.conf.j2
@@ -20,7 +20,7 @@ logfile {{ icingadb_redis_logfile }}
 databases {{ icingadb_redis_databases }}
 always-show-logo {{ icingadb_redis_always_show_logo }}
 
-{% if icingadb_redis_password %}
+{% if icingadb_redis_password is defined %}
 requirepass {{ icingadb_redis_password }}
 {% endif %}
 

--- a/roles/icingadb_redis/templates/icingadb-redis.conf.j2
+++ b/roles/icingadb_redis/templates/icingadb-redis.conf.j2
@@ -20,6 +20,10 @@ logfile {{ icingadb_redis_logfile }}
 databases {{ icingadb_redis_databases }}
 always-show-logo {{ icingadb_redis_always_show_logo }}
 
+{% if icingadb_redis_password %}
+requirepass {{ icingadb_redis_password }}
+{% endif %}
+
 ################################ SNAPSHOTTING  ################################
 #
 # Save the DB on disk:


### PR DESCRIPTION
For now we added basic `requirepass` capabilities. We might want to look into other, more advanced available configuration options?