### PR TITLE
Role icingaweb2: fix false datatype for config.ini

### DIFF
--- a/roles/icingaweb2/defaults/main.yml
+++ b/roles/icingaweb2/defaults/main.yml
@@ -26,8 +26,8 @@ icingaweb2_authentication:
 
 icingaweb2_config:
   global:
-    show_stacktraces: 1
-    show_application_state_messages: 1
+    show_stacktraces: "1"
+    show_application_state_messages: "1"
     config_resource: icingaweb2_db
     module_path: /usr/share/icingaweb2/modules
   logging:


### PR DESCRIPTION
Error message: expected str instance, int found.
The number (1) was interpreted as an integer without quoting