### PR TITLE
Fixed typo in api.yml

### DIFF
--- a/changelogs/fragments/fixed_typo_in_api_yml_file.yml
+++ b/changelogs/fragments/fixed_typo_in_api_yml_file.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed typo in api.yml file (exits to exists)

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -69,12 +69,12 @@
 
 - name: create new CA
   block:
-    - name: check ca key already exits
+    - name: check ca key already exists
       stat:
         path: "{{ icinga2_ca_path }}/ca.key"
       register: icinga2_ca_key_path
 
-    - name: check ca cert already exits
+    - name: check ca cert already exists
       stat:
         path: "{{ icinga2_ca_path }}/ca.crt"
       register: icinga2_ca_cert_path
@@ -85,12 +85,12 @@
       when: icinga2_ca_cert_path.stat.exists == false and icinga2_ca_key_path.stat.exists == false
   when: icinga2_ca_host is defined and icinga2_ca_host == 'none'
 
-- name: check cert key already exits
+- name: check cert key already exists
   stat:
     path: "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.key"
   register: icinga2_ssl_key_path
 
-- name: check certificate already exits
+- name: check certificate already exists
   stat:
     path: "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt"
   register: icinga2_ssl_cert_path


### PR DESCRIPTION
I am currently using ansible-collection-icinga to programmatically provision icinga and came across this typo. Thought it would be helpful :) 