### PR TITLE
Add variable for dependency repositories within monitoring_plugins role

### DIFF
--- a/changelogs/fragments/fix-173-changeable-dependency-repos.yml
+++ b/changelogs/fragments/fix-173-changeable-dependency-repos.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add variable `icinga_monitoring_plugins_dependency_repos` to allow for later modification by the user if specific other repositories need to be activated instead of `powertools` / `crb`

--- a/doc/role-monitoring_plugins/role-monitoring_plugins.md
+++ b/doc/role-monitoring_plugins/role-monitoring_plugins.md
@@ -17,7 +17,8 @@ The list is based on the section *"Plugin Check Commands for Monitoring Plugins"
 
 - `icinga_monitoring_plugins_dependency_repos: list`
   Decides which repositories are temporarily enabled when installing packages. Defaults to either `crb` or `powertools`.  
-  If the need arises, you can manually overwrite this variable to temporarily enable one or multiple repositories of your choice.
+  If the need arises, you can manually overwrite this variable to temporarily enable one or multiple repositories of your choice.  
+  You may specify `icinga_monitoring_plugins_dependency_repos: "*"` to temporarily enable every repository present.
 
 - `icinga_monitoring_plugins_remove: boolean`  
   Decides whether to remove packages that have not been asked for by the user. Default `true`  

--- a/doc/role-monitoring_plugins/role-monitoring_plugins.md
+++ b/doc/role-monitoring_plugins/role-monitoring_plugins.md
@@ -15,6 +15,10 @@ The list is based on the section *"Plugin Check Commands for Monitoring Plugins"
   Decides whether to run the equivalent of `dnf --enablerepo crb ...` when installing the necessary packages. Default: `false`  
   Enabling CRB/Powertools may be necessary, depending on the plugins wanted and the repositories already enabled.
 
+- `icinga_monitoring_plugins_dependency_repos: list`
+  Decides which repositories are temporarily enabled when installing packages. Defaults to either `crb` or `powertools`.  
+  If the need arises, you can manually overwrite this variable to temporarily enable one or multiple repositories of your choice.
+
 - `icinga_monitoring_plugins_remove: boolean`  
   Decides whether to remove packages that have not been asked for by the user. Default `true`  
   The requested check commands are compared against the list of available check commands. Packages not required for installation are removed.

--- a/roles/monitoring_plugins/defaults/main.yml
+++ b/roles/monitoring_plugins/defaults/main.yml
@@ -5,3 +5,5 @@ icinga_monitoring_plugins_epel: false
 icinga_monitoring_plugins_crb: false
 icinga_monitoring_plugins_remove: true
 icinga_monitoring_plugins_autoremove: false
+icinga_monitoring_plugins_dependency_repos:
+  - "{{ 'powertools' if ansible_distribution_major_version == '8' and icinga_monitoring_plugins_crb else 'crb' if ansible_distribution_major_version == '9' and icinga_monitoring_plugins_crb }}"

--- a/roles/monitoring_plugins/tasks/install_on_RedHat.yml
+++ b/roles/monitoring_plugins/tasks/install_on_RedHat.yml
@@ -27,7 +27,7 @@
     state: present
     name: "{{ needed_packages }}"
     update_cache: true
-    enablerepo: "{{ 'powertools' if ansible_distribution_major_version == '8' and icinga_monitoring_plugins_crb else 'crb' if ansible_distribution_major_version == '9' and icinga_monitoring_plugins_crb }}"
+    enablerepo: "{{ icinga_monitoring_plugins_dependency_repos }}"
   when:
     - ansible_distribution_major_version >= "8"
     - needed_packages is defined


### PR DESCRIPTION
In order to install some of the `nagios-plugins-...` packages either `crb` or `powertools` is needed.  
Currently the appropriate repository is temporarily enabled while installing.

The decision on whether to use `crb` or `powertools` is now sourced out to a new variable `icinga_monitoring_plugins_dependency_repos`.  
This in turn allows for the user to overwrite that variable to temporarily allow for any repository to be enabled.

If `crb` / `powertools` do not suffice, the user can *'manually'* set the variable to something like this:

```yaml
icinga_monitoring_plugins_dependency_repos:
  - "repo1"
  - "repo2"
  ...
```

Alternatively it can be specified as

```yaml
icinga_monitoring_plugins_dependency_repos: "*"
```

to temporarily enable every known repository.


This fixes #173