### PR TITLE
Fix incorrect cycle of installation and removal

### DIFF
--- a/changelogs/fragments/bugfix-monitoring-plugins-installation-removal-cycle.yml
+++ b/changelogs/fragments/bugfix-monitoring-plugins-installation-removal-cycle.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix incorrect behaviour within `monitoring_plugins` that lead to a cycle of installation and removal of the same packages within one play

--- a/roles/monitoring_plugins/tasks/install_on_Debian.yml
+++ b/roles/monitoring_plugins/tasks/install_on_Debian.yml
@@ -16,7 +16,7 @@
   become: yes
   apt:
     state: absent
-    name: "{{ (unwanted_packages | difference('monitoring-plugins-common') | difference('monitoring-plugins-basic')) if icinga_monitoring_plugins_check_commands else unwanted_packages }}"
+    name: "{{ (unwanted_packages | difference(['monitoring-plugins-common', 'monitoring-plugins-basic'])) if icinga_monitoring_plugins_check_commands else unwanted_packages }}"
     autoremove: "{{ icinga_monitoring_plugins_autoremove }}"
   when:
     - icinga_monitoring_plugins_remove

--- a/roles/monitoring_plugins/tasks/install_on_RedHat.yml
+++ b/roles/monitoring_plugins/tasks/install_on_RedHat.yml
@@ -37,7 +37,7 @@
   become: yes
   yum:
     state: absent
-    name: "{{ (unwanted_packages | difference('nagios-plugins')) if icinga_monitoring_plugins_check_commands else unwanted_packages }}"
+    name: "{{ (unwanted_packages | difference(['nagios-plugins'])) if icinga_monitoring_plugins_check_commands else unwanted_packages }}"
     autoremove: "{{ icinga_monitoring_plugins_autoremove }}"
   when:
     - icinga_monitoring_plugins_remove


### PR DESCRIPTION
The role `monitoring_plugins` has an issue where it tries to subtract one list from the other using the `difference` filter but fails to do so.  
Actually, it currently tries to subtract a string from a list which results in the list entry (that should be removed) to remain in the list.

Thus, this can lead to a cycle where a package is installed in one task and immediately removed in the next one, completely breaking idempotency and not achieving the goal.


This PR correctly subtracts lists from lists and should resolve the issue.