### PR TITLE
add installation for x509 module

### DIFF
--- a/changelogs/fragments/feature_add_x509_module_installation.yml
+++ b/changelogs/fragments/feature_add_x509_module_installation.yml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - Added Installation of x509 certificate monitoring model

--- a/doc/role-icingaweb2/module-x509.md
+++ b/doc/role-icingaweb2/module-x509.md
@@ -72,7 +72,7 @@ To import the database schema use `database` dictionary with the following varia
 | `port` | `int` | Defines the database port to connect to. | `3306` or `5432` |
 | `user` | `string` | Defines database user | `x509` |
 | `name` | `String` | Defines the database to connect to. | `x509` |
-| `password` | `String` | Defines the database password to connect with. | `x509` |
+| `password` | `String` | Defines the database password to connect with. | OMITTED |
 | `ssl_mode` | `String` | Clients attempt to connect using encryption, falling back to an unencrypted connection if an encrypted connection cannot be established |**n/a** |
 |`ssl_ca`| `String`| Defines the path to the ca certificate for client authentication. | **n/a** |
 |`ssl_cert`|`String`| Defines the path to the certificate for client authentication. | **n/a** |

--- a/doc/role-icingaweb2/module-x509.md
+++ b/doc/role-icingaweb2/module-x509.md
@@ -47,7 +47,7 @@ icingaweb2_modules:
 #### Import Certificates
 
 To import certificates use the **list** `certificate_files` all files need to be
-available locally beforehand. 
+available locally beforehand.
 
 ```
 icingaweb2_modules:
@@ -59,4 +59,37 @@ icingaweb2_modules:
         resource: x509
     certificate_files:
       - /etc/ssl/certs/ca-certificates.crt
+```
+
+#### Database Schema Setup
+
+To import the database schema use `database` dictionary with the following variables.
+
+| Variable | Type | Description | Default |
+|----------|------|-------------|---------|
+| `import_schema` | `Boolean` | Defines wether the schema will be imported or not. | false |
+| `host` | `String` | Defines database address to connect to. | `localhost` |
+| `port` | `int` | Defines the database port to connect to. | `3306` or `5432` |
+| `user` | `string` | Defines database user | `x509` |
+| `name` | `String` | Defines the database to connect to. | `x509` |
+| `password` | `String` | Defines the database password to connect with. | `x509` |
+| `ssl_mode` | `String` | Clients attempt to connect using encryption, falling back to an unencrypted connection if an encrypted connection cannot be established |**n/a** |
+|`ssl_ca`| `String`| Defines the path to the ca certificate for client authentication. | **n/a** |
+|`ssl_cert`|`String`| Defines the path to the certificate for client authentication. | **n/a** |
+|`ssl_key`| `String` | Defines the path to the certificate key for client key authentication. | **n/a** |
+|`ssl_cipher`|`String`| Ciphers for the client authentication. | **n/a** |
+|`ssl_extra_options`|`String`| Extra options for the client authentication. | **n/a** |
+
+
+```
+icingaweb2_modules:
+  x509:
+    source: package
+    enabled: true
+    database:
+      import_schema: true
+      host: localhost
+      port: 3306
+      user: x509
+      password: secret
 ```

--- a/doc/role-icingaweb2/module-x509.md
+++ b/doc/role-icingaweb2/module-x509.md
@@ -1,0 +1,62 @@
+## Module x509
+
+### Variables and Configuration
+
+The general module parameter like `enabled` and `source` can be applied here.
+
+| Variable | Value      |
+|----------|------------|
+| enabled  | true/false |
+| source   | package    |
+
+#### Section configuration
+
+The backend database for the module needs to be available and configured at the `icingaweb2_resources` variable.
+
+```
+icingaweb2_modules:
+  x509:
+    source: package
+    enabled: true
+    config:
+      backend:
+        resource: x509
+```
+
+#### Configure SNI Names.
+
+To configure SNIs for a IP address, use the dictionary `sni`.
+
+Example:
+
+```
+icingaweb2_modules:
+  x509:
+    source: package
+    enabled: true
+    config:
+      backend:
+        resource: x509
+    sni:
+      192.168.56.213:
+        hostnames:
+          - icinga.com
+          - test2.icinga.com
+```
+
+#### Import Certificates
+
+To import certificates use the **list** `certificate_files` all files need to be
+available locally beforehand. 
+
+```
+icingaweb2_modules:
+  x509:
+    source: package
+    enabled: true
+    config:
+      backend:
+        resource: x509
+    certificate_files:
+      - /etc/ssl/certs/ca-certificates.crt
+```

--- a/roles/icingaweb2/tasks/main.yml
+++ b/roles/icingaweb2/tasks/main.yml
@@ -43,3 +43,11 @@
     force: yes
   when: icingaweb2_modules is defined
   loop: "{{ icingaweb2_modules | dict2items }}"
+
+# Many daemons fail before e.g. the resource is set up or the schema hasn't been migrated. This is a workaround.
+- name: Manage enabled module daemons
+  ansible.builtin.service:
+    name: "icinga-{{ item.key }}"
+    state: restarted
+  when: icingaweb2_modules is defined and item.value.enabled|bool == true and item.key in ['vspheredb', 'x509']
+  loop: "{{ icingaweb2_modules | dict2items }}"

--- a/roles/icingaweb2/tasks/manage_mysql_imports.yml
+++ b/roles/icingaweb2/tasks/manage_mysql_imports.yml
@@ -1,0 +1,38 @@
+---
+- name: Check Database Credentials
+  ansible.builtin.assert:
+    that:
+      - _db['user'] is defined
+      - _db['password'] is defined
+    fail_msg: "No database credentials defined."
+
+- name: Build mysql command
+  ansible.builtin.set_fact:
+    _tmp_mysqlcmd: >-
+      mysql {% if _db['host'] | default('localhost') != 'localhost'  %} -h "{{ _db['host'] }}" {%- endif %}
+      {% if _db['port'] is defined %} -P "{{ _db['port'] }}" {%- endif %}
+      {% if _db['ssl_mode'] is defined %} --ssl-mode "{{ _db['ssl_mode'] }}" {%- endif %}
+      {% if _db['ssl_ca'] is defined %} --ssl-ca "{{ _db['ssl_ca'] }}" {%- endif %}
+      {% if _db['ssl_cert'] is defined %} --ssl-cert "{{ _db['ssl_cert'] }}" {%- endif %}
+      {% if _db['ssl_key'] is defined %} --ssl-key "{{ _db['ssl_key'] }}" {%- endif %}
+      {% if _db['ssl_cipher'] is defined %} --ssl-cipher "{{ _db['ssl_cipher'] }}" {%- endif %}
+      {% if _db['ssl_extra_options'] is defined %} {{ _db['ssl_extra_options'] }} {%- endif %}
+      -u "{{ _db['user'] }}"
+      -p"{{ _db['password'] }}"
+      "{{ _db['name'] }}"
+
+- name: MySQL check for db schema
+  ansible.builtin.shell: >
+    {{ _tmp_mysqlcmd }}
+    -Ns -e "{{ _db['select_query'] }}"
+  failed_when: false
+  changed_when: false
+  check_mode: false
+  register: _db_schema
+
+- name: MySQL import  db schema
+  ansible.builtin.shell: >
+    {{ _tmp_mysqlcmd }}
+    < {{ _db['schema_path'] }}
+  when: _db_schema.rc != 0
+  run_once: yes

--- a/roles/icingaweb2/tasks/modules/x509.yml
+++ b/roles/icingaweb2/tasks/modules/x509.yml
@@ -1,0 +1,66 @@
+- name: Module x509 | Ensure config directory
+  ansible.builtin.file:
+    state: directory
+    dest: "{{ icingaweb2_modules_config_dir }}/{{ _module }}"
+    owner: "{{ icingaweb2_httpd_user }}"
+    group: "{{ icingaweb2_group }}"
+    mode: "2770"
+  vars:
+    _module: "{{ item.key }}"
+
+- name: Module x509 | Manage config files
+  ansible.builtin.include_tasks: manage_module_config.yml
+  loop: "{{ _files }}"
+  loop_control:
+    loop_var: _file
+  when: vars['icingaweb2_modules'][_module][_file] is defined
+  vars:
+    _module: "{{ item.key }}"
+    _files:
+      - config
+      - sni
+
+- name: Module x509 | Manage Schema
+  block:
+    - name: Module x509 | Prepare _db informations
+      ansible.builtin.set_fact:
+        _db:
+          host: "{{ vars['icingaweb2_modules'][_module]['database']['host'] | default('localhost') }}"
+          port: "{{ vars['icingaweb2_modules'][_module]['database']['port'] | default('3306') }}"
+          user: "{{ vars['icingaweb2_modules'][_module]['database']['user'] | default('x509') }}"
+          password: "{{ vars['icingaweb2_modules'][_module]['database']['password'] | default(omit) }}"
+          name: "{{ vars['icingaweb2_modules'][_module]['database']['name'] | default('x509') }}"
+          ssl_mode: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_mode'] | default(omit) }}"
+          ssl_ca: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_ca'] | default(omit) }}"
+          ssl_cert: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_cert'] | default(omit) }}"
+          ssl_key: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_key'] | default(omit) }}"
+          ssl_cipher: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_cipher'] | default(omit) }}"
+          ssl_extra_options: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_extra_options'] | default(omit) }}"
+          schema_path: /usr/share/icingaweb2/modules/x509/schema/mysql.schema.sql
+          select_query: "select * from x509_certificate"
+      when: vars['icingaweb2_modules'][_module]['database']['type'] | default('mysql') == 'mysql'
+
+    - ansible.builtin.fail:
+        fail_msg: "The Database type select is not supported, {{ vars['icingaweb2_modules'][_module]['database']['type'] }} [Supported=mysql]"
+      when: vars['icingaweb2_modules'][_module]['database']['type'] is defined and vars['icingaweb2_modules'][_module]['database']['type'] != 'mysql'
+
+    - name: Module x509 | Import Schema
+      ansible.builtin.include_tasks: ../manage_mysql_imports.yml
+
+    - name: Module x509 | empty _db var
+      ansible.builtin.set_fact:
+        _db: {}
+  when: vars['icingaweb2_modules'][_module]['database']['import_schema'] | default(false)
+  vars:
+    _module: "{{ item.key }}"
+
+- name: Module x509 | Import Certificates
+  ansible.builtin.shell: >
+    icingacli {{ _module }} import --file {{ _file }}
+  loop: "{{ vars['icingaweb2_modules'][_module]['certificate_files'] }}"
+  loop_control:
+    loop_var: _file
+  vars:
+    _module: "{{ item.key }}"
+  when: vars['icingaweb2_modules'][_module]['certificate_files'] is defined
+  changed_when: false

--- a/roles/icingaweb2/vars/main.yml
+++ b/roles/icingaweb2/vars/main.yml
@@ -2,3 +2,4 @@
 icingaweb2_module_packages:
   icingadb: icingadb-web
   director: icinga-director
+  x509: icinga-x509


### PR DESCRIPTION
Adds x509 module, including configuration of SNIs and CAs. I also added some internal logic for restarting web module daemons at the very end of the Icingaweb2 installation, when (supposedly) all needed configuration is done. #197 will profit from this, too.

Fixes #186 