### PR TITLE
Adjusts actions so scenarios don't **always** run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ on:
       - 'feature/**'
       - 'fix/**'
       - '!doc/**'
+    paths:
+      - roles/**
+      - plugins/**
+      - molecule/**
+      - tests/**
   pull_request:
     branches:
       - 'feature/**'


### PR DESCRIPTION
In addition to omitting certain branch names, I thought it might be an idea to run the molecule scenarios only when actual content of the roles or other internal logic has been submitted.