### PR TITLE
Adds docs on database setup

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -47,6 +47,36 @@ ansible-galaxy collection build ansible-collection-icinga
 ansible-galaxy collection install icinga-icinga-0.3.0.tar.gz
 ```
 
+## Databases
+
+Icinga2 relies on relational databases for many parts of its functionality. **None** of those databases gets installed by the roles. You need to install and configure them yourself. For doing so, there are many ways available, e.g. the Ansible role [geerlingguy.mysql](https://galaxy.ansible.com/geerlingguy/mysql) for MySQL flavour (both MySQL and MariaDB) or [geerlingguy.postgresql](https://galaxy.ansible.com/geerlingguy/postgresql) PostGresQL:
+
+```yaml
+- name: Configure databases for Icinga2
+  hosts: database
+  vars:
+    mysql_databases:
+      - name: icingadb
+      - name: icingaweb
+      - name: vspheredb
+        encoding: utf8mb4
+        collation: utf8mb4_unicode_ci
+      - name: director
+    mysql_users:
+      - name: icingadb-user
+        host: localhost
+        password: icingadb-password
+        priv: "icingadb.*:ALL"
+    [...]
+  roles:
+    - role: geerlingguy.mysql
+```
+
+> [!NOTE]
+> Schema migrations needed for the respective Icinga components to work will be handled either by the respective roles or by the Icinga components themselves.
+
+
+
 ## Example Playbooks
 
 This is an example on how to install an Icinga 2 server/master instance.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -49,7 +49,7 @@ ansible-galaxy collection install icinga-icinga-0.3.0.tar.gz
 
 ## Databases
 
-Icinga2 relies on relational databases for many parts of its functionality. **None** of those databases gets installed by the roles. You need to install and configure them yourself. For doing so, there are many ways available, e.g. the Ansible role [geerlingguy.mysql](https://galaxy.ansible.com/geerlingguy/mysql) for MySQL flavour (both MySQL and MariaDB) or [geerlingguy.postgresql](https://galaxy.ansible.com/geerlingguy/postgresql) PostGresQL:
+Icinga2 relies on relational databases for many parts of its functionality. **None** of those databases get installed by the roles. You need to install and configure them yourself. For doing so, there are many ways available, e.g. the Ansible role [geerlingguy.mysql](https://galaxy.ansible.com/geerlingguy/mysql) for MySQL flavours (both MySQL and MariaDB) or [geerlingguy.postgresql](https://galaxy.ansible.com/geerlingguy/postgresql) for PostGresQL:
 
 ```yaml
 - name: Configure databases for Icinga2

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,11 +1,19 @@
 ### Getting Started
 
-The collection includes two roles in the current version.
+The collection includes six roles in the current version.
 
 * icinga.repos: Role to manage repositories
   * [Documentation: doc/role-repos](role-repos/role-repos.md)
 * icinga.icinga2: Role to install and manage Icinga 2 instances.
   * [Documentation: doc/role-icinga2](role-icinga2/role-icinga2.md)
+* icinga.icingadb: Role to install and manage IcingaDB, Icinga2's new data backend.
+  * [Documentation: doc/role-icingadb](role-icingadb/role-icingadb.md)
+* icinga.icingadb_redis: Role to install and manage Redis, IcingaDB's cache backend.
+  * [Documentation: doc/role-icingadb_redis](role-icingadb_redis/role-icingadb_redis.md)
+* icinga.icingaweb2: Role to install and manage Icinga Web 2.
+  * [Documentation: doc/role-icingaweb2](role-icingaweb2/role-icingaweb2.md)
+* icinga.monitoring_plugins: Role to install and manage Icinga2 compatible monitoring plugins.
+  * [Documentation: doc/role-monitoring_plugins](role-monitoring_plugins/role-monitoring_plugins.md)
 
 
 ---

--- a/doc/role-icingadb/role-icingadb.md
+++ b/doc/role-icingadb/role-icingadb.md
@@ -5,7 +5,12 @@ This role installs and configures the IcingaDB daemon. In addition it can also i
 It serves as the official, more performant successor to Icinga IDO. More information about its purpose and design can be found [in the official documentation](https://icinga.com/docs/icinga-db/latest/doc/01-About/).
 
 
-> :information_source: In many scenarios you want to install the [icingadb_redis role](../role-icingadb_redis/) together with this role. It is part of this collection, too.
+> [!TIP]
+> In many scenarios you want to install the [icingadb_redis role](../role-icingadb_redis/) together with this role. It is part of this collection, too.
+
+## Database
+
+IcingaDB relies on a relational database to persist received data. This database **won't** be created by this role - you need to deploy and configure one in advance. For more information, see the [Databases](../getting-started.md#databases) section in the getting started guide.
 
 ## Variables
 

--- a/doc/role-icingaweb2/role-icingaweb2.md
+++ b/doc/role-icingaweb2/role-icingaweb2.md
@@ -7,6 +7,10 @@ The role icingaweb2 installs and configures Icinga Web 2 and its modules.
 * [IcingaDB](./module-icingadb.md)
 * [Monitoring](./module-monitoring.md)
 
+## Databases
+
+Icingaweb2 and some of its modules rely on a relational database to persist data. These databases **won't** be created by this role - you need to deploy and configure them in advance. For more information, see the [Databases](../getting-started.md#databases) section in the getting started guide.
+
 ## Variables
 
 ### Icinga Web 2 DB Configuration


### PR DESCRIPTION
This is in reaction to #185 and adds information regarding database installation + configuration to the docs.

An example of installing and configuring needed databases using `geerlingguy.mysql` has been added to the getting started guide, too.

Fixes #185 