### PR TITLE
Adds installation of icingaweb2 modules from GitHub releases

### DIFF
--- a/changelogs/fragments/minor_change_add_git_installation.yml
+++ b/changelogs/fragments/minor_change_add_git_installation.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Adds possibility of installing modules from source (git)

--- a/doc/role-icingaweb2/module-monitoring.md
+++ b/doc/role-icingaweb2/module-monitoring.md
@@ -4,7 +4,7 @@ The module Monitoring is the main module for the deprecated IDO backend.
 
 ## Configuration
 
-The general module parameter `enabled` be applied here.
+The general module parameters like `enabled` can be applied here.
 
 For every config file, create a dictionary with sections as keys and the parameters as values. For all parameters please check the [module documentation](https://icinga.com/docs/icinga-web/latest/doc/03-Configuration/#configuration)
 

--- a/doc/role-icingaweb2/module-x509.md
+++ b/doc/role-icingaweb2/module-x509.md
@@ -2,12 +2,7 @@
 
 ### Variables and Configuration
 
-The general module parameter like `enabled` and `source` can be applied here.
-
-| Variable | Value      |
-|----------|------------|
-| enabled  | true/false |
-| source   | package    |
+The general module parameters like `enabled` and `source` can be applied here.
 
 #### Section configuration
 

--- a/doc/role-icingaweb2/role-icingaweb2.md
+++ b/doc/role-icingaweb2/role-icingaweb2.md
@@ -11,6 +11,28 @@ The role icingaweb2 installs and configures Icinga Web 2 and its modules.
 
 Icingaweb2 and some of its modules rely on a relational database to persist data. These databases **won't** be created by this role - you need to deploy and configure them in advance. For more information, see the [Databases](../getting-started.md#databases) section in the getting started guide.
 
+## Modules
+
+All modules get configured as child objects of the `icingaweb2_modules` variable. All modules can be installed **from source** by setting `source: git`. By default, this role installs the module from the official Icinga repositories, if available. When installing from source, the **latest tagged release** from GitHub will be installed.
+
+The following example displays different module configurations: 
+
+> [!WARNING]
+> Most configuration per module has been **omitted** for brevity, please see the respective module configuration docs
+
+```yaml
+icingaweb2_modules:
+  icingadb:
+    enabled: true
+    source: package  # install package from the official repos
+  director:
+    enabled: true
+    source: package
+  reporting:
+    enabled: true
+    source: git  # install from source due to lack of package
+```
+
 ## Variables
 
 ### Icinga Web 2 DB Configuration

--- a/roles/icingaweb2/tasks/main.yml
+++ b/roles/icingaweb2/tasks/main.yml
@@ -14,12 +14,17 @@
 
 - name: Gather module packages
   ansible.builtin.set_fact:
-    icingaweb2_packages: "{{ icingaweb2_packages + [ icingaweb2_module_packages[item.key] ] }}"
+    icingaweb2_packages: "{{ icingaweb2_packages + [icingaweb2_module_packages[item.key]] }}"
   loop: "{{ icingaweb2_modules | dict2items }}"
-  when: icingaweb2_modules is defined and icingaweb2_module_packages[item.key] is defined and item.value.enabled is true and item.value.source == "package"
+  when: icingaweb2_modules is defined and icingaweb2_module_packages[item.key] is defined and item.value.enabled|bool and item.value.source == "package"
 
 - name: Include OS specific installation
   ansible.builtin.include_tasks: "install_on_{{ ansible_os_family | lower }}.yml"
+
+- name: Include module installation from source
+  ansible.builtin.include_tasks: "modules/install_modules_from_source.yml"
+  when: icingaweb2_modules is defined
+  loop: "{{ icingaweb2_modules | dict2items }}"
 
 - name: Manage Icinga Web 2 config
   ansible.builtin.include_tasks: "manage_icingaweb_config.yml"
@@ -35,12 +40,13 @@
 
 - name: Manage enabled/disabled modules
   ansible.builtin.file:
-    src: "{{ icingaweb2_config.global.module_path + '/' + item.key if item.value.enabled|bool == true else omit }}"
+    src: "{{ icingaweb2_config.global.module_path + '/' + item.key if item.value.enabled | bool else omit }}"
     dest: "{{ icingaweb2_config_dir }}/enabledModules/{{ item.key }}"
     owner: "{{ icingaweb2_httpd_user }}"
     group: "{{ icingaweb2_group }}"
-    state: "{{ 'link' if item.value.enabled|bool == true else 'absent' }}"
+    state: "{{ 'link' if item.value.enabled | bool else 'absent' }}"
     force: yes
+    mode: "0777"
   when: icingaweb2_modules is defined
   loop: "{{ icingaweb2_modules | dict2items }}"
 
@@ -49,5 +55,5 @@
   ansible.builtin.service:
     name: "icinga-{{ item.key }}"
     state: restarted
-  when: icingaweb2_modules is defined and item.value.enabled|bool == true and item.key in ['vspheredb', 'x509']
+  when: icingaweb2_modules is defined and item.value.enabled | bool and item.key in ['reporting', 'director', 'vspheredb', 'x509']
   loop: "{{ icingaweb2_modules | dict2items }}"

--- a/roles/icingaweb2/tasks/modules/director.yml
+++ b/roles/icingaweb2/tasks/modules/director.yml
@@ -43,9 +43,3 @@
   ansible.builtin.shell:
     cmd: icingacli director kickstart run
   when: vars['icingaweb2_modules']['director']['run_kickstart'] is defined and vars['icingaweb2_modules']['director']['run_kickstart'] and vars['icingaweb2_modules']['director']['kickstart'] is defined and _required.rc|int == 0
-
-- name: Module Director | Ensure daemon is running
-  ansible.builtin.service:
-    name: "{{ icingaweb2_director_service }}"
-    state: started
-    enabled: yes

--- a/roles/icingaweb2/tasks/modules/install_modules_from_source.yml
+++ b/roles/icingaweb2/tasks/modules/install_modules_from_source.yml
@@ -1,0 +1,39 @@
+---
+- name: "Install module from source: {{ _module }}"
+  when: vars['icingaweb2_modules'][_module]['source'] == 'git'
+  vars:
+    _module: "{{ item.key }}"
+  block:
+    - name: Download release {{ icingaweb2_module_source_versions[_module] }}
+      ansible.builtin.get_url:
+        url: https://github.com/Icinga/icingaweb2-module-{{ _module }}/archive/refs/tags/{{ icingaweb2_module_source_versions[_module] }}.tar.gz
+        dest: /tmp/
+        mode: "0644"
+      register: _download
+  
+    - name: Extract source archive
+      ansible.builtin.unarchive:
+        src: "{{ _download.dest }}"
+        dest: "{{ _download.dest | dirname }}"
+        owner: "{{ icingaweb2_httpd_user }}"
+        group: "{{ icingaweb2_group }}"
+        mode: "0755"
+        remote_src: true
+
+    - name: Create module directory
+      ansible.builtin.file:
+        state: directory
+        dest: "{{ icingaweb2_config.global.module_path }}/{{ _module }}"
+        owner: "{{ icingaweb2_httpd_user }}"
+        group: "{{ icingaweb2_group }}"
+        mode: "0755"
+
+    - name: Move module to module path
+      ansible.builtin.copy:
+        src: "{{ _download.dest | dirname }}/{{ _download.dest | basename | regex_replace('\\.tar\\.gz', '') }}/"
+        dest: "{{ icingaweb2_config.global.module_path }}/{{ _module }}"
+        owner: "{{ icingaweb2_httpd_user }}"
+        group: "{{ icingaweb2_group }}"
+        mode: "0755"
+        force: true
+        remote_src: true

--- a/roles/icingaweb2/tasks/modules/x509.yml
+++ b/roles/icingaweb2/tasks/modules/x509.yml
@@ -64,3 +64,13 @@
     _module: "{{ item.key }}"
   when: vars['icingaweb2_modules'][_module]['certificate_files'] is defined
   changed_when: false
+
+- name: Module x509 | Ensure daemon service file is present
+  ansible.builtin.copy:
+    src: "{{ icingaweb2_config.global.module_path }}/x509/config/systemd/icinga-x509.service"
+    dest: /etc/systemd/system/icinga-x509.service
+    mode: "0644"
+    owner: root
+    group: root
+    remote_src: yes
+  when: icingaweb2_modules['x509']['source'] == 'git'

--- a/roles/icingaweb2/vars/main.yml
+++ b/roles/icingaweb2/vars/main.yml
@@ -4,3 +4,10 @@ icingaweb2_module_packages:
   director: icinga-director
   x509: icinga-x509
   businessprocess: icinga-businessprocess
+
+icingaweb2_module_source_versions:
+  businessprocess: v2.5.0
+  director: v1.11.0
+  icingadb: v1.1.1
+  reporting: v1.0.0
+  x509: v1.3.1


### PR DESCRIPTION
This is needed for some unpackaged Icingaweb2 modules anyways. The way I implemented it, it should work for all modules going forward, if they introduce the needed vars and extra tasks.

This is also a prerequisite to merge #217 as the reporting module can't be installed as a package (yet).