### PR TITLE
Fix/director installation

### DIFF
--- a/changelogs/fragments/feature_adjust_director_source_installation.yml
+++ b/changelogs/fragments/feature_adjust_director_source_installation.yml
@@ -1,0 +1,3 @@
+---
+minor_change:
+  - Adjusted the installation of the director module when using the source installation.

--- a/roles/icingaweb2/tasks/modules/director.yml
+++ b/roles/icingaweb2/tasks/modules/director.yml
@@ -1,3 +1,4 @@
+---
 - name: Module Director | Ensure config directory
   ansible.builtin.file:
     state: directory
@@ -18,7 +19,7 @@
       - kickstart
       - config
 
-- name: Module Director | Check for pending migrations
+- name: Module Director | Check for pending migrations  # noqa: command-instead-of-shell
   ansible.builtin.shell:
     cmd: icingacli director migration pending
   register: _pending
@@ -26,12 +27,12 @@
   failed_when: _pending.stdout|length > 0
   when: vars['icingaweb2_modules']['director']['import_schema'] is defined and vars['icingaweb2_modules']['director']['import_schema'] and vars['icingaweb2_modules']['director']['config'] is defined
 
-- name: Module Director | Apply pending migrations
+- name: Module Director | Apply pending migrations  # noqa: command-instead-of-shell
   ansible.builtin.shell:
     cmd: icingacli director migration run
   when: vars['icingaweb2_modules']['director']['import_schema'] is defined and vars['icingaweb2_modules']['director']['import_schema'] and vars['icingaweb2_modules']['director']['config'] is defined and _pending.rc|int == 0
 
-- name: Module Director | Check if kickstart is required
+- name: Module Director | Check if kickstart is required  # noqa: command-instead-of-shell
   ansible.builtin.shell:
     cmd: icingacli director kickstart required
   register: _required
@@ -39,13 +40,39 @@
   failed_when: _required.rc|int >= 2
   when: vars['icingaweb2_modules']['director']['run_kickstart'] is defined and vars['icingaweb2_modules']['director']['run_kickstart'] and vars['icingaweb2_modules']['director']['kickstart'] is defined
 
-- name: Module Director | Check if kickstart is required
+- name: Module Director | Check if kickstart is required  # noqa: command-instead-of-shell
   ansible.builtin.shell:
     cmd: icingacli director kickstart run
   when: vars['icingaweb2_modules']['director']['run_kickstart'] is defined and vars['icingaweb2_modules']['director']['run_kickstart'] and vars['icingaweb2_modules']['director']['kickstart'] is defined and _required.rc|int == 0
 
-- name: Module Director | Ensure daemon is running
-  ansible.builtin.service:
-    name: "{{ icingaweb2_director_service }}"
-    state: started
-    enabled: yes
+- name: Module Director | Ensure installation from source is complete
+  when: icingaweb2_modules['director']['source'] == 'git'
+  block:
+    - name: Module Director | Ensure daemon user exists
+      ansible.builtin.user:
+        name: icingadirector
+        state: present
+        shell: /bin/nologin
+        system: yes
+        home: /var/lib/icingadirector
+        group: "{{ icingaweb2_group }}"
+      when: icingaweb2_modules['director']['source'] == 'git'  # Only required for installations from source
+
+    - name: Module Director | Ensure home directory exists
+      ansible.builtin.file:
+        state: directory
+        dest: /var/lib/icingadirector
+        owner: icingadirector
+        group: "{{ icingaweb2_group }}"
+        mode: "0750"
+      when: icingaweb2_modules['director']['source'] == 'git'  # Only required for installations from source
+
+    - name: Module Director | Ensure systemd unit file exists
+      ansible.builtin.copy:
+        src: "{{ icingaweb2_config.global.module_path }}/director/contrib/systemd/icinga-director.service"
+        dest: /etc/systemd/system/icingadirector.service
+        owner: root
+        group: root
+        mode: "0644"
+        remote_src: yes
+      when: icingaweb2_modules['director']['source'] == 'git'  # Only required for installations from source

--- a/roles/icingaweb2/tasks/modules/director.yml
+++ b/roles/icingaweb2/tasks/modules/director.yml
@@ -56,7 +56,6 @@
         system: yes
         home: /var/lib/icingadirector
         group: "{{ icingaweb2_group }}"
-      when: icingaweb2_modules['director']['source'] == 'git'  # Only required for installations from source
 
     - name: Module Director | Ensure home directory exists
       ansible.builtin.file:
@@ -65,7 +64,6 @@
         owner: icingadirector
         group: "{{ icingaweb2_group }}"
         mode: "0750"
-      when: icingaweb2_modules['director']['source'] == 'git'  # Only required for installations from source
 
     - name: Module Director | Ensure systemd unit file exists
       ansible.builtin.copy:
@@ -75,4 +73,3 @@
         group: root
         mode: "0644"
         remote_src: yes
-      when: icingaweb2_modules['director']['source'] == 'git'  # Only required for installations from source


### PR DESCRIPTION
This adds a few things that need to be done 'manually' when installing the director module for Icingaweb2 from source.

This should get merged **before** #219 to avoid breaking installation strategies.