### PR TITLE
WIP: ADD roles/icingadb/tasks/install_on_suse.yml

### DIFF
--- a/roles/icingadb/tasks/install_on_suse.yml
+++ b/roles/icingadb/tasks/install_on_suse.yml
@@ -1,0 +1,4 @@
+- name: Suse - Install IcingaDB packages
+  ansible.builtin.package:
+    name: "{{ icingadb_packages }}"
+    state: present


### PR DESCRIPTION
AFAIK adding the Suse installation requires the `community.general.zypper` module (even though the task says `ansible.builtin.package`).

Should I add a `collections/requirements.yml` or a line in the `galaxy.yml` to make this visible?

fix #231 