### PR TITLE
ADD roles/icingadb_redis/tasks/install_on_suse.yml

### DIFF
--- a/roles/icingadb_redis/tasks/install_on_suse.yml
+++ b/roles/icingadb_redis/tasks/install_on_suse.yml
@@ -1,0 +1,5 @@
+---
+- name: Suse - install icingadb packages
+  ansible.builtin.package:
+    name: "{{ icingadb_redis_packages }}"
+    state: present


### PR DESCRIPTION
AFAIK adding the Suse installation requires the `community.general.zypper` module (even though the task says `ansible.builtin.package`).

Should I add a `collections/requirements.yml` or a line in the `galaxy.yml` to make this visible?

fix #232 