### PR TITLE
WIP: add Suse support for the repos role

### DIFF
--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -16,6 +16,8 @@ icinga_repo_apt_stable_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http:
 icinga_repo_apt_testing_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-testing main"
 icinga_repo_apt_snapshot_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-snapshots main"
 
+icinga_repo_zypper_key: "{{ icinga_repo_gpgkey }}"
+
 icinga_repo_gpgkey: "https://packages.icinga.com/icinga.key"
 icinga_repo_stable: true
 icinga_repo_testing: false

--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -17,6 +17,9 @@ icinga_repo_apt_testing_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http
 icinga_repo_apt_snapshot_deb: "deb [signed-by={{ icinga_repo_apt_keyring }}] http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release|lower }}-snapshots main"
 
 icinga_repo_zypper_key: "{{ icinga_repo_gpgkey }}"
+icinga_repo_zypper_stable_url: "https://packages.icinga.com/openSUSE/$releasever/release/"
+#icinga_repo_zypper_testing_url: ""
+icinga_repo_zypper_snapshot_url: "https://packages.icinga.com/openSUSE/$releasever/snapshot/"
 
 icinga_repo_gpgkey: "https://packages.icinga.com/icinga.key"
 icinga_repo_stable: true

--- a/roles/repos/handlers/main.yml
+++ b/roles/repos/handlers/main.yml
@@ -1,2 +1,6 @@
 ---
 # handlers file for icinga_repos
+
+- name: Run zypper refresh
+  ansible.builtin.command:
+    cmd: zypper refresh

--- a/roles/repos/tasks/Suse.yml
+++ b/roles/repos/tasks/Suse.yml
@@ -1,0 +1,57 @@
+---
+
+- name: Suse - add RPM key
+  ansible.builtin.rpm_key:
+    state: present
+    key: "{{ icinga_repo_zypper_key }}"
+
+- name: Suse - add Icinga repository (stable)
+  ansible.builtin.copy:
+    dest: /etc/zypp/repos.d/icinga-stable-release.repo
+    owner: root
+    group: root
+    mode: '0644'
+    content: |
+      [icinga-stable-release]
+      name=ICINGA (stable release for openSUSE)
+      baseurl={{ icinga_repo_zypper_stable_url }}
+      enabled={{ '1' if icinga_repo_stable|bool else '0' }}
+      gpgcheck=1
+      gpgkey={{ icinga_repo_zypper_key }}
+  notify:
+    - Run zypper refresh
+
+#- name: Suse - add Icinga repository (testing)
+#  ansible.builtin.copy:
+#    dest: /etc/zypp/repos.d/icinga-testing-builds.repo
+#    owner: root
+#    group: root
+#    mode: '0644'
+#    content: |
+#      [icinga-testing-builds]
+#      name=ICINGA (testing builds for openSUSE)
+#      baseurl={{ icinga_repo_zypper_testing_url }}
+#      enabled={{ '1' if icinga_repo_testing | bool else '0' }}
+#      gpgcheck=1
+#      gpgkey={{ icinga_repo_zypper_key }}
+#  notify:
+#    - Run zypper refresh
+
+- name: Suse - add Icinga repository (snapshot)
+  ansible.builtin.copy:
+    dest: /etc/zypp/repos.d/icinga-snapshot-builds.repo
+    owner: root
+    group: root
+    mode: '0644'
+    content: |
+      [icinga-snapshot-builds]
+      name=ICINGA (snapshot builds for openSUSE)
+      baseurl={{ icinga_repo_zypper_snapshot_url }}
+      enabled={{ '1' if icinga_repo_snapshot | bool else '0' }}
+      gpgcheck=1
+      gpgkey={{ icinga_repo_zypper_key }}
+  notify:
+    - Run zypper refresh
+
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
I prefer to use the copy module instead of `community.general.zypper_repository`, as the latter does not support the check mode.

I found no testing repository for Suse/openSUSE, only stable and snapshot?