### PR TITLE
execute the pgsqlcmd with LANG=C to make sure the output is in english and we can match for '(0 rows)' in the next task

### DIFF
--- a/roles/icingaweb2/tasks/manage_icingaweb_pgsql_db.yml
+++ b/roles/icingaweb2/tasks/manage_icingaweb_pgsql_db.yml
@@ -45,6 +45,7 @@
   block:
     - name: PostgreSQL check for icingaweb admin user
       ansible.builtin.shell: >
+        LANG=C
         {{ _tmp_pgsqlcmd }}
         -w -c "select name from icingaweb_user where name like '{{ icingaweb2_admin_username }}'"
       failed_when: false


### PR DESCRIPTION
If the LANG variable is set to anything other than english, it might be that the output does not contain `(0 rows)`, but contains e.g. `(0 Zeilen)` instead (in a German settting).

Prefixing the psqslcmd with `LANG=C` makes sure the output is always english...