### PR TITLE
remove superfluous curly brace

### DIFF
--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -136,7 +136,7 @@
         {% if icinga2_ca_host != 'none' %} --cert "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt" {% else %} --csr "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.csr" {%- endif %}
 
     - name: delegate ticket request to master
-      shell: icinga2 pki ticket --cn "{{ icinga2_cert_name }}{% if icinga2_ticket_salt is defined %} --salt {{ icinga2_ticket_salt }}{% endif %}}"
+      shell: icinga2 pki ticket --cn "{{ icinga2_cert_name }}{% if icinga2_ticket_salt is defined %} --salt {{ icinga2_ticket_salt }}{% endif %}"
       delegate_to: "{{ icinga2_delegate_host | default(icinga2_ca_host) }}"
       register: icinga2_ticket
       when: icinga2_ca_host != 'none'


### PR DESCRIPTION
Currently ticket creation is broken because cn option has a trailing curly brace.