### PR TITLE
Adjusts variable lookups

### DIFF
--- a/changelogs/fragments/minor_change_adjust_vars_lookup.yml
+++ b/changelogs/fragments/minor_change_adjust_vars_lookup.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Adjusted the way variables get looked up from `vars['varname']` to `varname` in most places.

--- a/roles/icingaweb2/tasks/modules/businessprocess.yml
+++ b/roles/icingaweb2/tasks/modules/businessprocess.yml
@@ -21,7 +21,7 @@
     src: "files/{{ _file.src_path }}"
     dest: "{{ icingaweb2_modules_config_dir }}/{{ item.key }}/processes/{{ _file.name }}"
   when: vars['icingaweb2_modules'][_module]['custom_process_files'] is defined
-  loop: "{{ vars['icingaweb2_modules'][_module]['custom_process_files'] }}"
+  loop: "{{ icingaweb2_modules[_module].custom_process_files }}"
   loop_control:
     loop_var: _file
   vars:

--- a/roles/icingaweb2/tasks/modules/director.yml
+++ b/roles/icingaweb2/tasks/modules/director.yml
@@ -25,12 +25,12 @@
   register: _pending
   changed_when: _pending.rc|int == 0
   failed_when: _pending.stdout|length > 0
-  when: vars['icingaweb2_modules']['director']['import_schema'] is defined and vars['icingaweb2_modules']['director']['import_schema'] and vars['icingaweb2_modules']['director']['config'] is defined
+  when: vars['icingaweb2_modules']['director']['import_schema'] is defined and icingaweb2_modules.director.import_schema and vars['icingaweb2_modules']['director']['config'] is defined
 
 - name: Module Director | Apply pending migrations  # noqa: command-instead-of-shell
   ansible.builtin.shell:
     cmd: icingacli director migration run
-  when: vars['icingaweb2_modules']['director']['import_schema'] is defined and vars['icingaweb2_modules']['director']['import_schema'] and vars['icingaweb2_modules']['director']['config'] is defined and _pending.rc|int == 0
+  when: vars['icingaweb2_modules']['director']['import_schema'] is defined and icingaweb2_modules.director.import_schema and vars['icingaweb2_modules']['director']['config'] is defined and _pending.rc|int == 0
 
 - name: Module Director | Check if kickstart is required  # noqa: command-instead-of-shell
   ansible.builtin.shell:
@@ -38,12 +38,12 @@
   register: _required
   changed_when: _required.rc|int == 0
   failed_when: _required.rc|int >= 2
-  when: vars['icingaweb2_modules']['director']['run_kickstart'] is defined and vars['icingaweb2_modules']['director']['run_kickstart'] and vars['icingaweb2_modules']['director']['kickstart'] is defined
+  when: vars['icingaweb2_modules']['director']['run_kickstart'] is defined and icingaweb2_modules.director.run_kickstart and vars['icingaweb2_modules']['director']['kickstart'] is defined
 
 - name: Module Director | Check if kickstart is required  # noqa: command-instead-of-shell
   ansible.builtin.shell:
     cmd: icingacli director kickstart run
-  when: vars['icingaweb2_modules']['director']['run_kickstart'] is defined and vars['icingaweb2_modules']['director']['run_kickstart'] and vars['icingaweb2_modules']['director']['kickstart'] is defined and _required.rc|int == 0
+  when: vars['icingaweb2_modules']['director']['run_kickstart'] is defined and icingaweb2_modules.director.run_kickstart and vars['icingaweb2_modules']['director']['kickstart'] is defined and _required.rc|int == 0
 
 - name: Module Director | Ensure installation from source is complete
   when: icingaweb2_modules['director']['source'] == 'git'

--- a/roles/icingaweb2/tasks/modules/manage_module_config.yml
+++ b/roles/icingaweb2/tasks/modules/manage_module_config.yml
@@ -1,6 +1,6 @@
 - name: Module {{ _module }} | Set file content as hash
   ansible.builtin.set_fact:
-    _i2_config_hash: "{{ lookup('list', vars['icingaweb2_modules'][_module][_file]) }}"
+    _i2_config_hash: "{{ lookup('list', icingaweb2_modules[_module][_file]) }}"
 
 - name: Module {{ _module }} | Write config file {{ _file }}.ini
   ansible.builtin.template:

--- a/roles/icingaweb2/tasks/modules/x509.yml
+++ b/roles/icingaweb2/tasks/modules/x509.yml
@@ -28,7 +28,7 @@
           host: "{{ vars['icingaweb2_modules'][_module]['database']['host'] | default('localhost') }}"
           port: "{{ vars['icingaweb2_modules'][_module]['database']['port'] | default('3306') }}"
           user: "{{ vars['icingaweb2_modules'][_module]['database']['user'] | default('x509') }}"
-          password: "{{ vars['icingaweb2_modules'][_module]['database']['password'] | default(omit) }}"
+          password: "{{ icingaweb2_modules[_module]['database']['password'] | default(omit) }}"
           name: "{{ vars['icingaweb2_modules'][_module]['database']['name'] | default('x509') }}"
           ssl_mode: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_mode'] | default(omit) }}"
           ssl_ca: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_ca'] | default(omit) }}"

--- a/roles/icingaweb2/tasks/modules/x509.yml
+++ b/roles/icingaweb2/tasks/modules/x509.yml
@@ -25,24 +25,24 @@
     - name: Module x509 | Prepare _db informations
       ansible.builtin.set_fact:
         _db:
-          host: "{{ vars['icingaweb2_modules'][_module]['database']['host'] | default('localhost') }}"
-          port: "{{ vars['icingaweb2_modules'][_module]['database']['port'] | default('3306') }}"
-          user: "{{ vars['icingaweb2_modules'][_module]['database']['user'] | default('x509') }}"
-          password: "{{ icingaweb2_modules[_module]['database']['password'] | default(omit) }}"
-          name: "{{ vars['icingaweb2_modules'][_module]['database']['name'] | default('x509') }}"
-          ssl_mode: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_mode'] | default(omit) }}"
-          ssl_ca: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_ca'] | default(omit) }}"
-          ssl_cert: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_cert'] | default(omit) }}"
-          ssl_key: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_key'] | default(omit) }}"
-          ssl_cipher: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_cipher'] | default(omit) }}"
-          ssl_extra_options: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_extra_options'] | default(omit) }}"
+          host: "{{ icingaweb2_modules[_module].database.host | default('localhost') }}"
+          port: "{{ icingaweb2_modules[_module].database.port | default('3306') }}"
+          user: "{{ icingaweb2_modules[_module].database.user | default('x509') }}"
+          password: "{{ icingaweb2_modules[_module].database.password | default(omit) }}"
+          name: "{{ icingaweb2_modules[_module].database.name | default('x509') }}"
+          ssl_mode: "{{ icingaweb2_modules[_module].database.ssl_mode | default(omit) }}"
+          ssl_ca: "{{ icingaweb2_modules[_module].database.ssl_ca | default(omit) }}"
+          ssl_cert: "{{ icingaweb2_modules[_module].database.ssl_cert | default(omit) }}"
+          ssl_key: "{{ icingaweb2_modules[_module].database.ssl_key | default(omit) }}"
+          ssl_cipher: "{{ icingaweb2_modules[_module].database.ssl_cipher | default(omit) }}"
+          ssl_extra_options: "{{ icingaweb2_modules[_module].database.ssl_extra_options | default(omit) }}"
           schema_path: /usr/share/icingaweb2/modules/x509/schema/mysql.schema.sql
           select_query: "select * from x509_certificate"
-      when: vars['icingaweb2_modules'][_module]['database']['type'] | default('mysql') == 'mysql'
+      when: icingaweb2_modules[_module].database.type | default('mysql') == 'mysql'
 
     - ansible.builtin.fail:
-        fail_msg: "The Database type select is not supported, {{ vars['icingaweb2_modules'][_module]['database']['type'] }} [Supported=mysql]"
-      when: vars['icingaweb2_modules'][_module]['database']['type'] is defined and vars['icingaweb2_modules'][_module]['database']['type'] != 'mysql'
+        fail_msg: "The Database type select is not supported, {{ icingaweb2_modules[_module].database.type }} [Supported=mysql]"
+      when: vars['icingaweb2_modules'][_module]['database']['type'] is defined and icingaweb2_modules[_module].database.type != 'mysql'
 
     - name: Module x509 | Import Schema
       ansible.builtin.include_tasks: ../manage_mysql_imports.yml
@@ -50,17 +50,17 @@
     - name: Module x509 | empty _db var
       ansible.builtin.set_fact:
         _db: {}
-  when: vars['icingaweb2_modules'][_module]['database']['import_schema'] | default(false)
+  when: icingaweb2_modules[_module].database.import_schema | default(false)
   vars:
     _module: "{{ item.key }}"
 
 - name: Module x509 | Import Certificates
   ansible.builtin.shell: >
     icingacli {{ _module }} import --file {{ _file }}
-  loop: "{{ vars['icingaweb2_modules'][_module]['certificate_files'] }}"
+  loop: "{{ icingaweb2_modules[_module].certificate_files }}"
   loop_control:
     loop_var: _file
   vars:
     _module: "{{ item.key }}"
-  when: vars['icingaweb2_modules'][_module]['certificate_files'] is defined
+  when: icingaweb2_modules[_module].certificate_files is defined
   changed_when: false


### PR DESCRIPTION
Right now, many variable lookups happen in the form of `vars['some']['nested'][variable]['value']`.

This can be problematic when the variable itself is another jinja-templated expression, see also #226 

Instead, we should look up variables like this wherever possible:

`some.nested[variable].value`

This PR adjusts all lookups which don't explicitly check the variable's existence via `is defined` to the alternative syntax.