### PR TITLE
added missing quotes to ticket delegation

### DIFF
--- a/changelogs/fragments/fix_missing_quotes_delegate_ticket.yml
+++ b/changelogs/fragments/fix_missing_quotes_delegate_ticket.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "icinga2 feature api: fixed missing quotes in delegate ticket command for satellites or second master nodes."

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -136,7 +136,7 @@
         {% if icinga2_ca_host != 'none' %} --cert "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt" {% else %} --csr "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.csr" {%- endif %}
 
     - name: delegate ticket request to master
-      shell: icinga2 pki ticket --cn "{{ icinga2_cert_name }}{% if icinga2_ticket_salt is defined %} --salt {{ icinga2_ticket_salt }}{% endif %}"
+      shell: icinga2 pki ticket --cn "{{ icinga2_cert_name }}" {% if icinga2_ticket_salt is defined %} --salt "{{ icinga2_ticket_salt }}"{% endif %}
       delegate_to: "{{ icinga2_delegate_host | default(icinga2_ca_host) }}"
       register: icinga2_ticket
       when: icinga2_ca_host != 'none'


### PR DESCRIPTION
Added missing quotes to ticket delegation. Currently, the ticket creation fails with the following error message:

```
TASK [icinga.icinga.icinga2 : delegate ticket request to master] ***********************************************************************************************************************************************************************************************************************************************************
changed: [host1.local -> host0.local] => {"changed": true, "cmd": "icinga2 pki ticket --cn \"host1.local --salt XXXXXXXX\"", "delta": "0:00:00.062976", "end": "2023-12-29 11:33:07.761888", "msg": "", "rc": 0, "start": "2023-12-29 11:33:07.698912", "stderr": "", "stderr_lines": [], "stdout": "fc043b935aacd292b742b0aaecd63e9055c16c95", "stdout_lines": ["fc043b935aacd292b742b0aaecd63e9055c16c95"]}

TASK [icinga.icinga.icinga2 : get certificate] *****************************************************************************************************************************************************************************************************************************************************************************
fatal: [host1.local]: FAILED! => {"changed": true, "cmd": "icinga2 pki  request --ticket \"fc043b935aacd292b742b0aaecd63e9055c16c95\" --host \"host0.local\" --port \"5665\" --ca \"/var/lib/icinga2/certs/ca.crt\" --key \"/var/lib/icinga2/certs/host1.local.key\" --trustedcert \"/var/lib/icinga2/certs/trusted-master.crt\"  --cert \"/var/lib/icinga2/certs/host1.local.crt\"", "delta": "0:00:00.130217", "end": "2023-12-29 11:33:09.363278", "msg": "non-zero return code", "rc": 1, "start": "2023-12-29 11:33:09.233061", "stderr": "", "stderr_lines": [], "stdout": "information/cli: Writing CA certificate to file '/var/lib/icinga2/certs/ca.crt'.\ncritical/cli: !!! Invalid ticket for CN 'host1.local'.", "stdout_lines": ["information/cli: Writing CA certificate to file '/var/lib/icinga2/certs/ca.crt'.", "critical/cli: !!! Invalid ticket for CN 'host1.local'."]}
```

the addition of the new quotes changes the command to an actual working command:

OLD: icinga2 pki ticket --cn \"host1.local --salt XXXXXXXX\"
NEW: icinga2 pki ticket --cn \"host1.local\" --salt \"XXXXXXXX\"