### PR TITLE
Fix/advanced ldap filters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,7 @@ on:
     paths:
       - roles/**
       - plugins/**
-      - molecule/**
-      - tests/**
+      - molecule/default/**
   pull_request:
     branches:
       - 'feature/**'

--- a/.github/workflows/test_icingaweb2_ini_template.yml
+++ b/.github/workflows/test_icingaweb2_ini_template.yml
@@ -1,4 +1,4 @@
-name: Python Unittest
+name: Icingaweb2 Templates
 on:
   push:
     tags:
@@ -17,7 +17,7 @@ on:
       - '!doc/**'
 
 jobs:
-  icingaweb2_ini_template:
+  test_ini_template:
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test_icingaweb2_ini_template.yml
+++ b/.github/workflows/test_icingaweb2_ini_template.yml
@@ -1,0 +1,61 @@
+name: Python Unittest
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+      - 'feature/**'
+      - 'fix/**'
+      - '!doc/**'
+    paths:
+      - 'roles/icingaweb2/templates/**'
+  pull_request:
+    branches:
+      - 'feature/**'
+      - 'fix/**'
+      - '!doc/**'
+
+jobs:
+  icingaweb2_ini_template:
+    runs-on: ubuntu-latest
+
+    env:
+      COLLECTION_NAMESPACE: icinga
+      COLLECTION_NAME: icinga
+
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        distro: [ubuntu2204]
+        python: ['3.9', '3.10']
+        ansible: ['2.13.10', '2.14.7']
+        scenario: [ini-configuration-tests]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies ansible
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements-test-${{ matrix.ansible }}.txt
+
+      - name: Install collection
+        run: |
+          mkdir -p ~/.ansible/collections/ansible_collections/$COLLECTION_NAMESPACE
+          cp -a ../ansible-collection-$COLLECTION_NAME ~/.ansible/collections/ansible_collections/$COLLECTION_NAMESPACE/$COLLECTION_NAME
+
+      - name: Test with molecule
+        run: |
+          ansible --version
+          molecule --version
+          molecule test -s ${{ matrix.scenario }}
+        env:
+          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/test_icingaweb2_ini_template.yml
+++ b/.github/workflows/test_icingaweb2_ini_template.yml
@@ -10,6 +10,7 @@ on:
       - '!doc/**'
     paths:
       - 'roles/icingaweb2/templates/**'
+      - 'molecule/ini-configuration-tests/**'
   pull_request:
     branches:
       - 'feature/**'

--- a/changelogs/fragments/fix_advanced_ldap_filters.yml
+++ b/changelogs/fragments/fix_advanced_ldap_filters.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - "Fix quoting for ! in templating Issue #208"
+  - "Replaced quote filter from ini template"

--- a/changelogs/fragments/fix_advanced_ldap_filters.yml
+++ b/changelogs/fragments/fix_advanced_ldap_filters.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix quoting for ! in templating Issue #208"

--- a/changelogs/fragments/minor_changes.yml
+++ b/changelogs/fragments/minor_changes.yml
@@ -2,3 +2,6 @@
 bugfixes:
   - "icingaweb2: run pqslcmd with LANG=C to ensure the output is in english."
   - remove superfluous curly brace (#246)
+minor_changes:
+  - added tests for icingaweb2 ini template
+  - added pyinilint as ini validator after templates

--- a/molecule/ini-configuration-tests/collections.yml
+++ b/molecule/ini-configuration-tests/collections.yml
@@ -1,0 +1,4 @@
+collections:
+  - name: community.docker
+  - name: community.general
+    version: ">=2,<3"

--- a/molecule/ini-configuration-tests/converge.yml
+++ b/molecule/ini-configuration-tests/converge.yml
@@ -15,7 +15,7 @@
       -  name: advanced_filter
          _i2_config_hash:
            section:
-             test: '(objectClass=user)'
+             test: '!(objectClass=user)'
              test2: "!(objectClass=user)"
              test3: "!attribute"
       -  name: list
@@ -28,7 +28,7 @@
       -  name: equal_sign
          _i2_config_hash:
            section:
-             test: 'equal=sign'
+             test: equal=sign
 
 
   collections:

--- a/molecule/ini-configuration-tests/converge.yml
+++ b/molecule/ini-configuration-tests/converge.yml
@@ -1,0 +1,42 @@
+---
+
+- name: Converge
+  hosts: all
+  vars:
+    test_cases:
+      -  name: string
+         _i2_config_hash:
+           section:
+             test: string
+      -  name: number
+         _i2_config_hash:
+           section:
+             test: 10
+      -  name: advanced_filter
+         _i2_config_hash:
+           section:
+             test: '(objectClass=user)'
+             test2: "!(objectClass=user)"
+             test3: "!attribute"
+      -  name: list
+         _i2_config_hash:
+           section:
+             test:
+               - "foo"
+               - bar
+               - 'baz'
+      -  name: equal_sign
+         _i2_config_hash:
+           section:
+             test: 'equal=sign'
+
+
+  collections:
+    - icinga.icinga
+  tasks:
+    - ansible.builtin.template:
+        src: "{{ lookup('ansible.builtin.env', 'MOLECULE_PROJECT_DIRECTORY', default=Undefined) }}/roles/icingaweb2/templates/modules_config.ini.j2"
+        dest: "/tmp/{{ item.name }}"
+      loop: "{{ test_cases }}"
+      vars:
+        _i2_config_hash: "{{ item._i2_config_hash }}"

--- a/molecule/ini-configuration-tests/converge.yml
+++ b/molecule/ini-configuration-tests/converge.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Converge
   hosts: all
   vars:

--- a/molecule/ini-configuration-tests/converge.yml
+++ b/molecule/ini-configuration-tests/converge.yml
@@ -33,9 +33,14 @@
   collections:
     - icinga.icinga
   tasks:
+    - ansible.builtin.pip:
+        name: pyinilint
+        state: present
+
     - ansible.builtin.template:
         src: "{{ lookup('ansible.builtin.env', 'MOLECULE_PROJECT_DIRECTORY', default=Undefined) }}/roles/icingaweb2/templates/modules_config.ini.j2"
         dest: "/tmp/{{ item.name }}"
+        validate: pyinilint %s
       loop: "{{ test_cases }}"
       vars:
         _i2_config_hash: "{{ item._i2_config_hash }}"

--- a/molecule/ini-configuration-tests/molecule.yml
+++ b/molecule/ini-configuration-tests/molecule.yml
@@ -1,0 +1,26 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: icinga-default
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  inventory:
+    link:
+      host_vars: host_vars/
+verifier:
+  name: testinfra
+  directory: tests/integration/
+lint: |
+  set -e
+  yamllint --no-warnings roles/
+  ansible-lint roles/

--- a/molecule/ini-configuration-tests/molecule.yml
+++ b/molecule/ini-configuration-tests/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: icinga-default
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2204}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/ini-configuration-tests/tests/integration/test_ini_config.py
+++ b/molecule/ini-configuration-tests/tests/integration/test_ini_config.py
@@ -2,28 +2,28 @@ def test_string(host):
     i2_file = host.file("/tmp/string")
     print(i2_file.content_string)
     assert i2_file.is_file
-    assert i2_file.content_string == "\n[section]\ntest = string"
+    assert i2_file.content_string == "\n[section]\ntest = string\n"
 
 def test_number(host):
     i2_file = host.file("/tmp/number")
     print(i2_file.content_string)
     assert i2_file.is_file
-    assert i2_file.content_string == '\n[section]\ntest = "10"'
+    assert i2_file.content_string == '\n[section]\ntest = "10"\n'
 
 def test_list(host):
     i2_file = host.file("/tmp/list")
     print(i2_file.content_string)
     assert i2_file.is_file
-    assert i2_file.content_string == '\n[section]\ntest = "foo, bar, baz"'
+    assert i2_file.content_string == '\n[section]\ntest = "foo, bar, baz"\n'
 
 def test_advanced_filter(host):
     i2_file = host.file("/tmp/advanced_filter")
     print(i2_file.content_string)
     assert i2_file.is_file
-    assert i2_file.content_string == "\n[section]\ntest = '!(objectClass=user)'\ntest2 = '!(objectClass=user)'\ntest3 = '!attribute'"
+    assert i2_file.content_string == "\n[section]\ntest = '!(objectClass=user)'\ntest2 = '!(objectClass=user)'\ntest3 = '!attribute'\n"
 
 def test_equal_sign(host):
     i2_file = host.file("/tmp/equal_sign")
     print(i2_file.content_string)
     assert i2_file.is_file
-    assert i2_file.content_string == "\n[section]\ntest = 'equal=sign'"
+    assert i2_file.content_string == "\n[section]\ntest = 'equal=sign'\n"

--- a/molecule/ini-configuration-tests/tests/integration/test_ini_config.py
+++ b/molecule/ini-configuration-tests/tests/integration/test_ini_config.py
@@ -1,0 +1,29 @@
+def test_string(host):
+    i2_file = host.file("/tmp/string")
+    print(i2_file.content_string)
+    assert i2_file.is_file
+    assert i2_file.content_string == "\n[section]\ntest = string"
+
+def test_number(host):
+    i2_file = host.file("/tmp/number")
+    print(i2_file.content_string)
+    assert i2_file.is_file
+    assert i2_file.content_string == '\n[section]\ntest = "10"'
+
+def test_list(host):
+    i2_file = host.file("/tmp/list")
+    print(i2_file.content_string)
+    assert i2_file.is_file
+    assert i2_file.content_string == '\n[section]\ntest = "foo, bar, baz"'
+
+def test_advanced_filter(host):
+    i2_file = host.file("/tmp/advanced_filter")
+    print(i2_file.content_string)
+    assert i2_file.is_file
+    assert i2_file.content_string == "\n[section]\ntest = '!(objectClass=user)'\ntest2 = '!(objectClass=user)'\ntest3 = '!attribute'"
+
+def test_equal_sign(host):
+    i2_file = host.file("/tmp/equal_sign")
+    print(i2_file.content_string)
+    assert i2_file.is_file
+    assert i2_file.content_string == "\n[section]\ntest = 'equal=sign'"

--- a/molecule/local-default/converge.yml
+++ b/molecule/local-default/converge.yml
@@ -5,6 +5,12 @@
     ansible.builtin.apt:
       cache_valid_time: 3600
   vars:
+    icingaweb2_groups:
+      icingaweb2_group_ldap:
+        resource: icingaweb2_ldap
+        user_backend: icingaweb2_user_ldap
+        group_class: group
+        group_filter: '!(objectClass=user)'
     icingaweb2_resources:
       director_db:
         type: db

--- a/roles/icingaweb2/templates/ini_template.j2
+++ b/roles/icingaweb2/templates/ini_template.j2
@@ -7,10 +7,8 @@
 {{ option }} = "{{ value }}"
 {% elif value is iterable and (value is not string and value is not mapping) %}
 {{ option }} = "{{ value | join(', ') }}"
-{% elif value|first == "!" %}
-{{ option }} = {{ value | quote }}
-{% elif value is string and "=" in value %}
-{{ option }} = {{ value | quote }}
+{% elif ( value is string and ( "=" in value or "!" in value ) )%}
+{{ option }} = '{{ value }}'
 {% else %}
 {{ option }} = {{ value }}
 {% endif %}

--- a/roles/icingaweb2/templates/ini_template.j2
+++ b/roles/icingaweb2/templates/ini_template.j2
@@ -7,8 +7,10 @@
 {{ option }} = "{{ value }}"
 {% elif value is iterable and (value is not string and value is not mapping) %}
 {{ option }} = "{{ value | join(', ') }}"
+{% elif value|first == "!" %}
+{{ option }} = {{ value | quote }}
 {% elif value is string and "=" in value %}
-{{ option }} = "{{ value | quote }}"
+{{ option }} = {{ value | quote }}
 {% else %}
 {{ option }} = {{ value }}
 {% endif %}


### PR DESCRIPTION
Changed template filter had double quoting active. 

Example: 
```
"{{ value | quote }}" 
```

Gives output like this:
```
"'test'"
```

In addition I'll make sure any string starting with "!" will be quoted. Otherwise only filters with "=" get quoted. Don't know if this is a thing. 

Fixes #208 