### PR TITLE
Feature/enhance icingadb retention config

### DIFF
--- a/changelogs/fragments/feature_enhance_icingadb_retention_configs.yml
+++ b/changelogs/fragments/feature_enhance_icingadb_retention_configs.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "Enhance IcingaDB retention configs #200"
+  - "Added tests for retention configs"

--- a/doc/role-icingadb/role-icingadb.md
+++ b/doc/role-icingadb/role-icingadb.md
@@ -57,6 +57,21 @@ For logging, currently only the **logging level** can be set. The default is `in
 |----------|------|-------------|---------|
 | `icingadb_logging_level` | `fatal\|error\|warn\|info\|debug` | Defines the logging level for IcingaDB. | `info` |
 
+### IcingaDB Retention
+
+| Variable | Type | Description | Default |
+|----------|------|-------------|---------|
+|`icingadb_retention_history_days`|`number`|Number of days to retain full historical data.|By default, historical data is retained forever.|
+|`icingadb_retention_sla_days`|`number`|Number of days to retain historical data for SLA reporting.|By default, it is retained forever.|
+|`icingadb_retention_acknowledgement`|`number`|Number of days to retain acknowledgements|If not limited by icingadb_retention_history_days, forever|
+|`icingadb_retention_comment`|`number`|Number of days to retain comments|If not limited by icingadb_retention_history_days, forever|
+|`icingadb_retention_downtime`|`number`|Number of days to retain downtimes|If not limited by icingadb_retention_history_days, forever|
+|`icingadb_retention_flapping`|`number`|Number of days to retain flapping events|If not limited by icingadb_retention_history_days, forever|
+|`icingadb_retention_notification`|`number`|Number of days to retain notifications|If not limited by icingadb_retention_history_days, forever|
+|`icingadb_retention_state`|`number`|Number of days to retain states|If not limited by icingadb_retention_history_days, forever|
+
+
+
 ### Miscellaneous
 
 The following variables are used for the IcingaDB setup and are not directly related to the configuration of IcingaDB itself. Normally, you can rely on the defaults to work and should **not** change them unless you know what you are doing.

--- a/molecule/default/host_vars/icinga-default.yaml
+++ b/molecule/default/host_vars/icinga-default.yaml
@@ -1,3 +1,14 @@
+# test_icingadb_retentions.py
+icingadb_retention_history_days: 10
+icingadb_retention_sla_days: 11
+icingadb_retention_acknowledgement: 20
+icingadb_retention_comment: 30
+icingadb_retention_downtime: 10
+icingadb_retention_state: 60
+icingadb_retention_notification: 4
+icingadb_retention_flapping: 2
+
+
 icinga2_custom_config:
   - name: icinga2_command
     path: zones.d/main/commands/custom_commands.conf

--- a/molecule/default/tests/integration/test_icingadb_retentions.py
+++ b/molecule/default/tests/integration/test_icingadb_retentions.py
@@ -1,0 +1,13 @@
+# Vars in host_vars
+
+def test_icingadb_config(host):
+    i2_file = host.file("/etc/icingadb/config.yml")
+    assert i2_file.is_file
+    assert i2_file.contains('  history-days: 10')
+    assert i2_file.contains('  sla-days: 11')
+    assert i2_file.contains('    acknowledgement: 20')
+    assert i2_file.contains('    comment: 30')
+    assert i2_file.contains('    state: 60')
+    assert i2_file.contains('    downtime: 10')
+    assert i2_file.contains('    notification: 4')
+    assert i2_file.contains('    flapping: 2')

--- a/molecule/local-default/host_vars/icinga-default.yaml
+++ b/molecule/local-default/host_vars/icinga-default.yaml
@@ -1,3 +1,14 @@
+# test_icingadb_retentions.py
+icingadb_retention_history_days: 10
+icingadb_retention_sla_days: 11
+icingadb_retention_acknowledgement: 20
+icingadb_retention_comment: 30
+icingadb_retention_downtime: 10
+icingadb_retention_state: 60
+icingadb_retention_notification: 4
+icingadb_retention_flapping: 2
+
+
 icinga2_objects:
   icinga-default:
     - name: root

--- a/molecule/local-default/molecule.yml
+++ b/molecule/local-default/molecule.yml
@@ -19,3 +19,8 @@ provisioner:
   inventory:
     link:
       host_vars: host_vars/
+verifier:
+  name: testinfra
+  options:
+    sudo: true
+  directory: tests/integration/

--- a/molecule/local-default/tests/integration/test_icingadb_retentions.py
+++ b/molecule/local-default/tests/integration/test_icingadb_retentions.py
@@ -1,0 +1,11 @@
+def test_icingadb_config(host):
+    i2_file = host.file("/etc/icingadb/config.yml")
+    assert i2_file.is_file
+    assert i2_file.contains('  history-days: 10')
+    assert i2_file.contains('  sla-days: 11')
+    assert i2_file.contains('    acknowledgement: 20')
+    assert i2_file.contains('    comment: 30')
+    assert i2_file.contains('    state: 60')
+    assert i2_file.contains('    downtime: 10')
+    assert i2_file.contains('    notification: 4')
+    assert i2_file.contains('    flapping: 2')

--- a/roles/icingadb/templates/icingadb.ini.j2
+++ b/roles/icingadb/templates/icingadb.ini.j2
@@ -84,19 +84,28 @@ logging:
 # Retention is an optional feature to limit the number of days that historical data is available,
 # as no historical data is deleted by default.
 retention:
-  # Number of days to retain full historical data. By default, historical data is retained forever.
-#  history-days:
-
-  # Number of days to retain historical data for SLA reporting. By default, it is retained forever.
-#  sla-days:
-
-  # Map of history category to number of days to retain its data in order to
-  # enable retention only for specific categories or to
-  # override the number that has been configured in history-days.
+{% if icingadb_retention_history_days is defined and icingadb_retention_history_days is number %}
+  history-days: {{ icingadb_retention_history_days }}
+{% endif %}
+{% if icingadb_retention_sla_days is defined and icingadb_retention_sla_days is number %}
+  sla-days: {{ icingadb_retention_sla_days }}
+{% endif %}
   options:
-#    acknowledgement:
-#    comment:
-#    downtime:
-#    flapping:
-#    notification:
-#    state:
+{% if icingadb_retention_acknowledgement is defined and icingadb_retention_acknowledgement is number %}
+    acknowledgement: {{ icingadb_retention_acknowledgement }}
+{% endif %}
+{% if icingadb_retention_comment is defined and icingadb_retention_comment is number %}
+    comment: {{ icingadb_retention_comment }}
+{% endif %}
+{% if icingadb_retention_downtime is defined and icingadb_retention_downtime is number %}
+    downtime: {{ icingadb_retention_downtime }}
+{% endif %}
+{% if icingadb_retention_flapping is defined and icingadb_retention_flapping is number %}
+    flapping: {{ icingadb_retention_flapping }}
+{% endif %}
+{% if icingadb_retention_notification is defined and icingadb_retention_notification is number %}
+    notification: {{ icingadb_retention_notification }}
+{% endif %}
+{% if icingadb_retention_state is defined and icingadb_retention_state is number %}
+    state: {{ icingadb_retention_state }}
+{% endif %}


### PR DESCRIPTION
This adds the retention configuration parameters to the role. 

Adds some tests in the build and via testinfra if the parameters are set in the file.

Adds documentation on every variable. 

Adds changelog fragments

fixes #200 