### PR TITLE
Fix module configuration task order

### DIFF
--- a/changelogs/fragments/fix_change_order_of_module_tasks.yml
+++ b/changelogs/fragments/fix_change_order_of_module_tasks.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Icingaweb2: Change order of module state and configuration tasks #225"

--- a/roles/icingaweb2/tasks/main.yml
+++ b/roles/icingaweb2/tasks/main.yml
@@ -28,12 +28,7 @@
   ansible.builtin.include_tasks: "manage_icingaweb_{{ icingaweb2_db.type }}_db.yml"
   when: icingaweb2_db is defined
 
-- name: Configure modules
-  ansible.builtin.include_tasks: "modules/{{ item.key }}.yml"
-  when: icingaweb2_modules is defined
-  loop: "{{ icingaweb2_modules | dict2items }}"
-
-- name: Manage enabled/disabled modules
+- name: Manage module states
   ansible.builtin.file:
     src: "{{ icingaweb2_config.global.module_path + '/' + item.key if item.value.enabled|bool == true else omit }}"
     dest: "{{ icingaweb2_config_dir }}/enabledModules/{{ item.key }}"
@@ -41,6 +36,13 @@
     group: "{{ icingaweb2_group }}"
     state: "{{ 'link' if item.value.enabled|bool == true else 'absent' }}"
     force: yes
+  when: icingaweb2_modules is defined
+  loop: "{{ icingaweb2_modules | dict2items }}"
+  loop_control:
+    label: "Ensure {{ item.key }} is {{ 'enabled' if item.value.enabled|bool == true else 'disabled' }}"
+
+- name: Configure modules
+  ansible.builtin.include_tasks: "modules/{{ item.key }}.yml"
   when: icingaweb2_modules is defined
   loop: "{{ icingaweb2_modules | dict2items }}"
 


### PR DESCRIPTION
This PR enables and disables modules before configuration. Normally modules get enabled and mostly configured after in the GUI. 

This should be the preferred way. 

fixes #225 