### PR TITLE
removed localhost condition as default

### DIFF
--- a/molecule/local-default-pgsql/converge.yml
+++ b/molecule/local-default-pgsql/converge.yml
@@ -3,7 +3,8 @@
   become: true
   vars:
     icingadb_database_type: pgsql
-    icingadb_database_host: 127.0.0.1
+    icingadb_database_host: localhost
+    icingadb_database_port: 5432
     icingadb_database_name: icingadb
     icingadb_database_user: icingadb
     icingadb_database_password: icingadb

--- a/roles/icingadb/tasks/manage_schema_pgsql.yml
+++ b/roles/icingadb/tasks/manage_schema_pgsql.yml
@@ -6,7 +6,7 @@
         _tmp_pgsqlcmd: >-
           PGPASSWORD="{{ icingadb_database_password }}"
           psql
-          "{% if icingadb_database_host | default('localhost') != 'localhost' %} host="{{ icingadb_database_host }}" {%- endif %}
+          "{% if icingadb_database_host %} host="{{ icingadb_database_host }}" {%- endif %}
           {% if icingadb_database_port is defined %} port={{ icingadb_database_port }} {%- endif %}
           user={{ icingadb_database_user | default('icingadb') }}
           dbname={{ icingadb_database_name | default('icingadb') }}


### PR DESCRIPTION
This fixes the issue that if icingadb_database_host is set to localhost, no host parameter is set on the commandline. Because it assumes it is a local connection. Which is not true if port is used as well. 

Could be a breaking change!


Fixes #256 