### PR TITLE
Suse 12 missing libboost dependency. 

### DIFF
--- a/changelogs/fragments/fix_suse12_dep_missing.yml
+++ b/changelogs/fragments/fix_suse12_dep_missing.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "fixed libboost_regex1_54_0 missing for Suse 12. thanks @dh-roland"

--- a/roles/icinga2/tasks/install_on_Suse.yml
+++ b/roles/icinga2/tasks/install_on_Suse.yml
@@ -9,8 +9,3 @@
     name: icinga2-selinux
     state: present
   when: ansible_selinux is defined and ansible_selinux.status == "enabled"
-
-- name: Zypper - install dep
-  community.general.zypper:
-    name: libboost_regex1_66_0
-    state: present

--- a/roles/icinga2/vars/Suse-12.yml
+++ b/roles/icinga2/vars/Suse-12.yml
@@ -1,5 +1,5 @@
 ---
-icinga2_packages: ["icinga2","libboost_regex1_66_0"]
+icinga2_packages: ["icinga2","libboost_regex1_54_0"]
 icinga2_user: icinga
 icinga2_group: icinga
 icinga2_config_path: /etc/icinga2


### PR DESCRIPTION
This is a PR which combines the PR #261 from @dh-roland and some reworking of the packages handling. 

Per default, the libboost_regex1_66_0 will be installed and if the variable ansible_distribution_major_version is 12 it will be the libboost_regex1_54_0.

@dh-roland can you verify if it works, somehow my suse vagrant environment isn't working properly. Would be good if you could test this PR. 

