### PR TITLE
issues/263 fixed references of "vars" to use "icingaweb2_modules"

### DIFF
--- a/roles/icingaweb2/tasks/modules/x509.yml
+++ b/roles/icingaweb2/tasks/modules/x509.yml
@@ -13,7 +13,7 @@
   loop: "{{ _files }}"
   loop_control:
     loop_var: _file
-  when: vars['icingaweb2_modules'][_module][_file] is defined
+  when: icingaweb2_modules[_module][_file] is defined
   vars:
     _module: "{{ item.key }}"
     _files:
@@ -21,32 +21,32 @@
       - sni
 
 - name: Module x509 | Manage Schema
-  when: vars['icingaweb2_modules'][_module]['database']['import_schema'] | default(false)
+  when: icingaweb2_modules[_module]['database']['import_schema'] | default(false)
   vars:
     _module: "{{ item.key }}"
   block:
     - name: Module x509 | Prepare _db informations
       ansible.builtin.set_fact:
         _db:
-          host: "{{ vars['icingaweb2_modules'][_module]['database']['host'] | default('localhost') }}"
-          port: "{{ vars['icingaweb2_modules'][_module]['database']['port'] | default('3306') }}"
-          user: "{{ vars['icingaweb2_modules'][_module]['database']['user'] | default('x509') }}"
-          password: "{{ vars['icingaweb2_modules'][_module]['database']['password'] | default(omit) }}"
-          name: "{{ vars['icingaweb2_modules'][_module]['database']['name'] | default('x509') }}"
-          ssl_mode: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_mode'] | default(omit) }}"
-          ssl_ca: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_ca'] | default(omit) }}"
-          ssl_cert: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_cert'] | default(omit) }}"
-          ssl_key: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_key'] | default(omit) }}"
-          ssl_cipher: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_cipher'] | default(omit) }}"
-          ssl_extra_options: "{{ vars['icingaweb2_modules'][_module]['database']['ssl_extra_options'] | default(omit) }}"
+          host: "{{ icingaweb2_modules[_module]['database']['host'] | default('localhost') }}"
+          port: "{{ icingaweb2_modules[_module]['database']['port'] | default('3306') }}"
+          user: "{{ icingaweb2_modules[_module]['database']['user'] | default('x509') }}"
+          password: "{{ icingaweb2_modules[_module]['database']['password'] | default(omit) }}"
+          name: "{{ icingaweb2_modules[_module]['database']['name'] | default('x509') }}"
+          ssl_mode: "{{ icingaweb2_modules[_module]['database']['ssl_mode'] | default(omit) }}"
+          ssl_ca: "{{ icingaweb2_modules[_module]['database']['ssl_ca'] | default(omit) }}"
+          ssl_cert: "{{ icingaweb2_modules[_module]['database']['ssl_cert'] | default(omit) }}"
+          ssl_key: "{{ icingaweb2_modules[_module]['database']['ssl_key'] | default(omit) }}"
+          ssl_cipher: "{{ icingaweb2_modules[_module]['database']['ssl_cipher'] | default(omit) }}"
+          ssl_extra_options: "{{ icingaweb2_modules[_module]['database']['ssl_extra_options'] | default(omit) }}"
           schema_path_mysql: /usr/share/icingaweb2/modules/x509/schema/mysql.schema.sql
           schema_path_pgsql: /usr/share/icingaweb2/modules/x509/schema/pgsql.schema.sql
           select_query: "select * from x509_certificate"
-          type: "{{ vars['icingaweb2_modules'][_module]['database']['type'] | default(omit) }}"
+          type: "{{ icingaweb2_modules[_module]['database']['type'] | default(omit) }}"
 
     - ansible.builtin.fail:
         fail_msg: No database type was provided
-      when: vars['icingaweb2_modules'][_module]['database']['type'] is not defined
+      when: icingaweb2_modules[_module]['database']['type'] is not defined
 
     - ansible.builtin.fail:
         fail_msg: "Invalid database type was provided. [Supported: mysql, pgsql]"
@@ -67,10 +67,10 @@
 - name: Module x509 | Import Certificates
   ansible.builtin.shell: >
     icingacli {{ _module }} import --file {{ _file }}
-  loop: "{{ vars['icingaweb2_modules'][_module]['certificate_files'] }}"
+  loop: "{{ icingaweb2_modules[_module]['certificate_files'] }}"
   loop_control:
     loop_var: _file
   vars:
     _module: "{{ item.key }}"
-  when: vars['icingaweb2_modules'][_module]['certificate_files'] is defined
+  when: icingaweb2_modules[_module]['certificate_files'] is defined
   changed_when: false


### PR DESCRIPTION
In reference to [Issue 263](https://github.com/Icinga/ansible-collection-icinga/issues/263), I replaced all references of "vars['icingaweb2_modules']" with just "icingaweb2_modules" as the use of "vars" was causing any use of templated variables to pass the template as a literal string instead of evaluating it for the desired value.