### PR TITLE
Fix hardcoded variables on including role repos

### DIFF
--- a/roles/monitoring_plugins/tasks/install_on_RedHat.yml
+++ b/roles/monitoring_plugins/tasks/install_on_RedHat.yml
@@ -1,15 +1,9 @@
 ---
-
 - name: Activate epel repository
-  include_role:
-    name: icinga.icinga.repos
-  vars:
-    icinga_repo_epel: true
-    icinga_repo_stable: false
-    icinga_repo_testing: false
-    icinga_repo_snapshot: false
-  when: icinga_monitoring_plugins_epel
-  when: icinga_monitoring_plugins_epel|bool == true
+  ansible.builtin.yum:
+    name: epel-release
+    state: present
+  when: icinga_monitoring_plugins_epel|bool
 
 - name: Yum - install requested packages
   become: yes


### PR DESCRIPTION
This was a intial idea to reuse the role repos for enabling the epel release. But if included it will deactivate the release repos and if not set to false. It will enable the repos even if you just want the epel release. 

So I will remove it and will install epel-release instead. 

@donien can you give your thoughts if this is the right way? 

ref #270 