### PR TITLE
Not tabbed correctly, caused build to fail

### DIFF
--- a/doc/role-icinga2/objects.md
+++ b/doc/role-icinga2/objects.md
@@ -470,11 +470,11 @@ icinga2_objects:
         description: The notification address
       -6: $notification_address6$
       -b: $notification_author$
-      vars:
-        +: true
-        notification_address: $address$
-        notification_address6: $address6$
-        notification_author: $notification.author$
+    vars:
+      +: true
+      notification_address: $address$
+      notification_address6: $address6$
+      notification_author: $notification.author$
 ````
 
 #### UserGroup


### PR DESCRIPTION
The documentation is not tabbed correctly causing build failures