### PR TITLE
[icinga2] fix file permissions for objects

### DIFF
--- a/roles/icinga2/tasks/configure.yml
+++ b/roles/icinga2/tasks/configure.yml
@@ -92,6 +92,7 @@
     delimiter: ' '
     owner: "{{ icinga2_user }}"
     group: "{{ icinga2_group }}"
+    mode: 0644
   loop: "{{ result.files }}"
   notify: reload icinga2 service
 

--- a/roles/icinga2/tasks/objects.yml
+++ b/roles/icinga2/tasks/objects.yml
@@ -34,6 +34,7 @@
         state: directory
         owner: root
         group: root
+        mode: 0755
         path: "{{ icinga2_fragments_path }}/{{ item.path }}/"
       loop: "{{ icinga2_custom_config }}"
 
@@ -41,6 +42,7 @@
       ansible.builtin.copy:
         owner: root
         group: root
+        mode: 0644
         src: "files/{{ item.name }}"
         dest: "{{ icinga2_fragments_path }}/{{ item.path }}/{{ item.order|default('20')|string }}_{{ item.name }}"
       loop: "{{ icinga2_custom_config }}"


### PR DESCRIPTION
Relying on the umask will break on systems which do not allow read for other, using a defined mode makes it independent from umask settings on the target system.