### PR TITLE
Add toggle to ignore unknown Icinga Web 2 modules

### DIFF
--- a/roles/icingaweb2/defaults/main.yml
+++ b/roles/icingaweb2/defaults/main.yml
@@ -3,6 +3,8 @@ icingaweb2_group: icingaweb2
 icingaweb2_modules_config_dir: "{{ icingaweb2_config_dir }}/modules"
 icingaweb2_director_service: icinga-director.service
 
+icingaweb2_ignore_unknown_modules: false
+
 icingaweb2_groups:
   icingaweb2:
     backend: db

--- a/roles/icingaweb2/tasks/main.yml
+++ b/roles/icingaweb2/tasks/main.yml
@@ -56,7 +56,7 @@
     - item.key in icingaweb2_module_packages.keys()
   loop: "{{ icingaweb2_modules | dict2items }}"
   loop_control:
-    label: "Ensure {{ item.key }} is {{ 'enabled' if item.value.enabled|bool == true else 'disabled' }}"
+    label: "Ensure {{ item.key }} is {{ 'enabled' if item.value.enabled|default(false)|bool == true else 'disabled' }}"
 
 - name: Configure modules
   ansible.builtin.include_tasks: "modules/{{ item.key }}.yml"
@@ -70,5 +70,5 @@
   ansible.builtin.service:
     name: "icinga-{{ item.key }}"
     state: restarted
-  when: icingaweb2_modules is defined and item.value.enabled|bool == true and item.key in ['vspheredb', 'x509']
+  when: icingaweb2_modules is defined and item.value.enabled|default(false)|bool == true and item.key in ['vspheredb', 'x509']
   loop: "{{ icingaweb2_modules | dict2items }}"

--- a/roles/icingaweb2/tasks/main.yml
+++ b/roles/icingaweb2/tasks/main.yml
@@ -12,6 +12,14 @@
       paths:
         - "{{ role_path }}/vars"
 
+- name: Check each icingaweb2_modules key against known modules
+  when: not icingaweb2_ignore_unknown_modules
+  loop: "{{ icingaweb2_modules | default({}) | dict2items }}"
+  ansible.builtin.assert:
+    that:
+      - item.key in icingaweb2_module_packages.keys()
+    fail_msg: "'{{ item.key }}' is an unknown module. Set 'icingaweb2_ignore_unknown_modules' to 'true' if you want to simply skip unknown modules"
+
 - name: Gather module packages
   ansible.builtin.set_fact:
     icingaweb2_packages: "{{ icingaweb2_packages + [ icingaweb2_module_packages[item.key] ] }}"
@@ -43,14 +51,18 @@
     group: "{{ icingaweb2_group }}"
     state: "{{ 'link' if item.value.enabled|bool == true else 'absent' }}"
     force: yes
-  when: icingaweb2_modules is defined
+  when:
+    - icingaweb2_modules is defined
+    - item.key in icingaweb2_module_packages.keys()
   loop: "{{ icingaweb2_modules | dict2items }}"
   loop_control:
     label: "Ensure {{ item.key }} is {{ 'enabled' if item.value.enabled|bool == true else 'disabled' }}"
 
 - name: Configure modules
   ansible.builtin.include_tasks: "modules/{{ item.key }}.yml"
-  when: icingaweb2_modules is defined
+  when:
+    - icingaweb2_modules is defined
+    - item.key in icingaweb2_module_packages.keys()
   loop: "{{ icingaweb2_modules | dict2items }}"
 
 # Many daemons fail before e.g. the resource is set up or the schema hasn't been migrated. This is a workaround.


### PR DESCRIPTION
Add a boolean `icingaweb2_ignore_unknown_errors` to ignore modules provided in `icingaweb2_modules` which are unknown to this collection.

This way users can define modules within `icingaweb2_modules` and use other Ansible code referencing the same variable without this collection's icingaweb2 role failing.

Fixes #288