### PR TITLE
Fix bad variable expansion concerning vars['var']

### DIFF
--- a/changelogs/fragments/fix_variable_expansion_breaks.yml
+++ b/changelogs/fragments/fix_variable_expansion_breaks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Changed variable lookups in the form of `vars['variablename']` to `variablename` to avoid explicitly looking up the `vars` key of a play.

--- a/roles/icingaweb2/tasks/manage_icingaweb_config.yml
+++ b/roles/icingaweb2/tasks/manage_icingaweb_config.yml
@@ -45,7 +45,7 @@
     - authentication
     - groups
   vars:
-    _i2_config_hash: "{{ vars['icingaweb2_' + item] }}"
+    _i2_config_hash: "{{ lookup('ansible.builtin.vars', 'icingaweb2_' + item) }}"
 
 - name: Prepare config hash
   ansible.builtin.set_fact:

--- a/roles/icingaweb2/tasks/modules/businessprocess.yml
+++ b/roles/icingaweb2/tasks/modules/businessprocess.yml
@@ -20,7 +20,7 @@
     group: "{{ icingaweb2_group }}"
     src: "files/{{ _file.src_path }}"
     dest: "{{ icingaweb2_modules_config_dir }}/{{ item.key }}/processes/{{ _file.name }}"
-  when: vars['icingaweb2_modules'][_module]['custom_process_files'] is defined
+  when: icingaweb2_modules[_module]['custom_process_files'] is defined
   loop: "{{ icingaweb2_modules[_module].custom_process_files }}"
   loop_control:
     loop_var: _file

--- a/roles/icingaweb2/tasks/modules/director.yml
+++ b/roles/icingaweb2/tasks/modules/director.yml
@@ -12,7 +12,7 @@
   loop: "{{ _files }}"
   loop_control:
     loop_var: _file
-  when: vars['icingaweb2_modules'][_module][_file] is defined
+  when: icingaweb2_modules[_module][_file] is defined
   vars:
     _module: "{{ item.key }}"
     _files:
@@ -25,12 +25,12 @@
   register: _pending
   changed_when: _pending.rc|int == 0
   failed_when: _pending.stdout|length > 0
-  when: vars['icingaweb2_modules']['director']['import_schema'] is defined and icingaweb2_modules.director.import_schema and vars['icingaweb2_modules']['director']['config'] is defined
+  when: icingaweb2_modules['director']['import_schema'] is defined and icingaweb2_modules.director.import_schema and icingaweb2_modules['director']['config'] is defined
 
 - name: Module Director | Apply pending migrations  # noqa: command-instead-of-shell
   ansible.builtin.shell:
     cmd: icingacli director migration run
-  when: vars['icingaweb2_modules']['director']['import_schema'] is defined and icingaweb2_modules.director.import_schema and vars['icingaweb2_modules']['director']['config'] is defined and _pending.rc|int == 0
+  when: icingaweb2_modules['director']['import_schema'] is defined and icingaweb2_modules.director.import_schema and icingaweb2_modules['director']['config'] is defined and _pending.rc|int == 0
 
 - name: Module Director | Check if kickstart is required  # noqa: command-instead-of-shell
   ansible.builtin.shell:
@@ -38,12 +38,12 @@
   register: _required
   changed_when: _required.rc|int == 0
   failed_when: _required.rc|int >= 2
-  when: vars['icingaweb2_modules']['director']['run_kickstart'] is defined and icingaweb2_modules.director.run_kickstart and vars['icingaweb2_modules']['director']['kickstart'] is defined
+  when: icingaweb2_modules['director']['run_kickstart'] is defined and icingaweb2_modules.director.run_kickstart and icingaweb2_modules['director']['kickstart'] is defined
 
 - name: Module Director | Run kickstart if required  # noqa: command-instead-of-shell
   ansible.builtin.shell:
     cmd: icingacli director kickstart run
-  when: vars['icingaweb2_modules']['director']['run_kickstart'] is defined and icingaweb2_modules.director.run_kickstart and vars['icingaweb2_modules']['director']['kickstart'] is defined and _required.rc|int == 0
+  when: icingaweb2_modules['director']['run_kickstart'] is defined and icingaweb2_modules.director.run_kickstart and icingaweb2_modules['director']['kickstart'] is defined and _required.rc|int == 0
 
 - name: Module Director | Ensure installation from source is complete
   when: icingaweb2_modules['director']['source'] == 'git'

--- a/roles/icingaweb2/tasks/modules/monitoring.yml
+++ b/roles/icingaweb2/tasks/modules/monitoring.yml
@@ -11,7 +11,7 @@
   loop: "{{ _files }}"
   loop_control:
     loop_var: _file
-  when: vars['icingaweb2_modules'][_module][_file] is defined
+  when: icingaweb2_modules[_module][_file] is defined
   vars:
     _module: "{{ item.key }}"
     _files:


### PR DESCRIPTION
Calling `vars['var']` is an explicit reference to the a play's `vars` key which makes defining those variables at host level impossible.

Also, when defining a variable in `vars` by providing a host variable the variable expansion breaks.
`vars` -> `key: "{{ host_variable_foo }}"` will be returned as a literal string when looked up via `vars['key']` without any expansion.

This commit fixes #291 by refering to just the variable name wherever suitable.