### PR TITLE
Better reflect the usage of `icinga2_objects`

### DIFF
--- a/changelogs/fragments/fix_292_icinga2_objects_documentation.yml
+++ b/changelogs/fragments/fix_292_icinga2_objects_documentation.yml
@@ -1,0 +1,4 @@
+---
+
+minor_changes:
+  - Change documentation to better reflect the intended usage of the variable 'icinga2_objects' as a host variable vs. as a play variable.

--- a/doc/role-icinga2/objects.md
+++ b/doc/role-icinga2/objects.md
@@ -7,14 +7,22 @@ generate configuration files with objects included.
 
 This variable consists of Icinga 2 object attributes and attributes referring to the file created in the process.
 
-> **_NOTE:_** The second level of the dictionary defines on which host the configuration is created. All objects in the example below, will be gathered and deployed on the host.: `host.example.org`.
-In addition this variable can be logically defined at the **host_vars/agent** and are still deployed on the master **host.example.org**
+> **_NOTE:_** The second level of the dictionary defines on which host the configuration is created. All objects in the example below, will be gathered and deployed on the host.: `host.example.org`.  
+In addition this variable can be logically defined at the **host_vars/agent** and are still deployed on the master **host.example.org**  
+The second level can **only** be used in **hostvars**!
 
 The `file` key will be used to control in which directory structure the object will be placed.
 In addition the `order` key will define the order of the objects in the destination file.
 The default for `order` is set to **10**, so everything below that number will be in front of the file, all objects with the order above 10 will be placed later in the file.
 
 The `type` will be the original Icinga 2 object types, a list of all can be found in the documentation. [Icinga 2 Monitoring Objects](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#monitoring-objects)
+
+### Icinga2 Objects in Hostvars
+
+When defining `icinga2_objects` as a host specific variable (hostvars/groupvars) you can define the variable as a dictionary. Each dictionary key represents the host on which the key's value will be deployed as configuration.  
+Alternatively you can define `icinga2_objects` as a list which results in the configuration being deployed on just the host for which the variable is defined.
+
+Example defining the variable within hostvars:
 
 ```
 icinga2_objects:
@@ -32,23 +40,32 @@ icinga2_objects:
       parent: main
 ```
 
-The advantage of the default **icinga2_objects** variable is, that you can run your playbook over many different server without deploying the
-monitoring configuration on every host in the playbook. Otherwise the variable should be only placed in `host_vars` files to restrict deployment on every host.
+This way you can use some host's variables (like `ansible_fqdn`) to deploy configuration on another host (in this case `host.example.org`).
 
-As a secondary option, you can use the variable without the second level like the following example.
+Additonally, the list `icinga2_objects` from within a play's `vars` key will be merged with each host's individual objects.
 
-> **CAUTION!** If not restricted it will be deployed on every host. This should be only defined in `host_vars` unless
-you know what you are doing!
+### Icinga2 Objects in Play Vars
+
+If you need to deploy certain Icinga 2 objects on every host in your play, you can define the variable `icinga2_objects` as a list within your play's `vars` key.  
+This makes sure that, **in addition** to the individual host's objects, there is a common set of objects between your hosts.
+
+Example defining the variable within your play's vars:
 
 ```
 icinga2_objects:
-  - name: "{{ ansible_fqdn }}"
-    type: Endpoint
-    file: "{{ 'conf.d/' + ansible_hostname + '.conf' }}"
+  - name: "GlobalApiUser"
+    type: ApiUser
+    file: "conf.d/global_api_users.conf"
     order: 20
+    password: supersecrectpassword123
+    permissions:
+      - "objects/query/Host"
+      - "objects/query/Service"
 ```
 
-More Examples at the end -> [Examples](#examples)
+---
+
+More examples at the end -> [Examples](#examples)
 
 ## Managing Config directories
 

--- a/doc/role-icinga2/objects.md
+++ b/doc/role-icinga2/objects.md
@@ -58,12 +58,12 @@ webserver.example.org:
 
 In the above case the list `icinga2_objects` will only be deployed as configuration on host `webserver.example.org`.
 
-Additonally, the list `icinga2_objects` from within a play's `vars` key will be merged with each host's individual objects.
+Additionally, the list `icinga2_objects` from within a play's `vars` key will be merged with each host's individual objects.
 
 ### Icinga2 Objects in Play Vars
 
 If you need to deploy certain Icinga 2 objects on every host in your play, you can define the variable `icinga2_objects` as a list within your play's `vars` key.  
-This makes sure that, **in addition** to the individual host's objects, there is a common set of objects between your hosts.
+This ensures that, **in addition** to the individual host's objects, there is a common set of objects between your hosts.
 
 Example defining the variable within your play's vars:
 

--- a/doc/role-icinga2/objects.md
+++ b/doc/role-icinga2/objects.md
@@ -8,7 +8,7 @@ generate configuration files with objects included.
 This variable consists of Icinga 2 object attributes and attributes referring to the file created in the process.
 
 > **_NOTE:_** The second level of the dictionary defines on which host the configuration is created. All objects in the example below, will be gathered and deployed on the host.: `host.example.org`.  
-In addition this variable can be logically defined at the **host_vars/agent** and are still deployed on the master **host.example.org**  
+In addition this variable can be logically defined at the **host_vars/agent** and are still deployed on the master **host.example.org**.  
 The second level can **only** be used in **hostvars**!
 
 The `file` key will be used to control in which directory structure the object will be placed.
@@ -22,25 +22,41 @@ The `type` will be the original Icinga 2 object types, a list of all can be foun
 When defining `icinga2_objects` as a host specific variable (hostvars/groupvars) you can define the variable as a dictionary. Each dictionary key represents the host on which the key's value will be deployed as configuration.  
 Alternatively you can define `icinga2_objects` as a list which results in the configuration being deployed on just the host for which the variable is defined.
 
-Example defining the variable within hostvars:
+Example defining the variable within hostvars as a dictionary (inventory entry):
 
-```
-icinga2_objects:
-  host.example.org:
-    - name: "{{ ansible_fqdn }}"
-      type: Endpoint
-      file: "{{ 'conf.d/' + ansible_hostname + '.conf' }}"
-      order: 20
-    - name: "{{ ansible_fqdn }}"
-      type: Zone
-      file: "{{ 'conf.d/' + ansible_hostname + '.conf' }}"
-      order: 20
-      endpoints:
-        - "{{ ansible_fqdn }}"
-      parent: main
+```yaml
+webserver.example.org:
+  ansible_host: 10.0.0.8
+  icinga2_objects:
+    host.example.org:
+      - name: "{{ inventory_hostname }}"
+        type: Host
+        file: "{{ 'conf.d/' + ansible_hostname + '.conf' }}"
+        address: "{{ ansible_host }}"
+        check_command: hostalive
+        check_interval: 3m
+      - ...
 ```
 
-This way you can use some host's variables (like `ansible_fqdn`) to deploy configuration on another host (in this case `host.example.org`).
+This way you can use some host's variables (like `ansible_host`) to deploy configuration on another host (in this case `host.example.org`).
+
+Example defining the variable within hostvars as a list (inventory entry):
+
+```yaml
+webserver.example.org:
+  ansible_host: 10.0.0.8
+  icinga2_objects:
+    - name: "web-api-user"
+      type: ApiUser
+      file: "{{ 'conf.d/' + ansible_hostname + '.conf' }}"
+      password: "somepassword"
+      permissions:
+        - "objects/query/Host"
+        - "objects/query/Service"
+    - ...
+```
+
+In the above case the list `icinga2_objects` will only be deployed as configuration on host `webserver.example.org`.
 
 Additonally, the list `icinga2_objects` from within a play's `vars` key will be merged with each host's individual objects.
 


### PR DESCRIPTION
Change the documentation to better explain the intended behaviour of the variable `icinga2_objects`.
Shows the difference between this variable as a host variable and as a play variable.

Since the (allowed) usage differes here, this is now also reflected in the documentation.

Fixes #292