### PR TITLE
Fix ssl_cacert variable on configuration of icinga2 api feature with custom certificates

### DIFF
--- a/changelogs/fragments/fix_update_ca_ssl_cert_documentation
+++ b/changelogs/fragments/fix_update_ca_ssl_cert_documentation
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixes documentation for the variable name to use when deploying external certificates. from ssl_ca to ssl_cacert.

--- a/doc/role-icinga2/features/feature-api.md
+++ b/doc/role-icinga2/features/feature-api.md
@@ -123,7 +123,7 @@ If you want to use certificates which aren't created by **Icinga 2 CA**, then us
 the following variables to point the role to your own certificates.
 
 ```
-ssl_ca: ca.crt
+ssl_cacert: ca.crt
 ssl_cert: certificate.crt
 ssl_key: certificate.key
 ```


### PR DESCRIPTION
Fixes documentation.
The correct variable name for the certificate authority certificate is ssl_cacert (not ssl_ca), as per playbook output.

```
fatal: [myhostFQDN]: FAILED! => {
    "assertion": "((icinga2_ssl_cacert is defined and icinga2_ssl_cert is defined and icinga2_ssl_key is defined) or (icinga2_ssl_cacert is undefined and icinga2_ssl_cert is undefined and icinga2_ssl_key is undefined and icinga2_ca_host is defined))",

```
vs

```
TASK [icinga.icinga.icinga2 : api feature cleanup arguments list] *****************************************************
ok: [myhostFQDN] => (item={'key': 'name', 'value': 'api'})
ok: [myhostFQDN] => (item={'key': 'accept_config', 'value': True})
ok: [myhostFQDN] => (item={'key': 'accept_commands', 'value': True})
ok: [myhostFQDN] => (item={'key': 'ticket_salt', 'value': 'TicketSalt'})
skipping: [myhostFQDN] => (item={'key': 'ssl_cacert', 'value': 'ca.crt'})
skipping: [myhostFQDN] => (item={'key': 'ssl_cert', 'value': 'myhostFQDN.crt'})
skipping: [myhostFQDN] => (item={'key': 'ssl_key', 'value': 'myhostFQDN.key'})
skipping: [myhostFQDN] => (item={'key': 'endpoints', 'value': [{'name': 'NodeName'}, {'name': 'icinga-1.mydomain.local'}, {'name': 'icinga-2.mydomain.local'}]})
skipping: [myhostFQDN] => (item={'key': 'zones', 'value': [{'name': 'ZoneName', 'parent': 'master', 'endpoints': ['NodeName']}, {'name': 'master', 'endpoints': ['icinga-1.mydomain.local', 'icinga-2.mydomain.local']}, {'name': 'global', 'global': True}, {'name': 'global-external', 'global': True}]})

```