### PR TITLE
Add tasks to create icingadb-redis log directory

### DIFF
--- a/changelogs/fragments/fix_issue_298.yml
+++ b/changelogs/fragments/fix_issue_298.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Icinga's packages no longer create '/var/log/icingadb-redis/'. Added tasks that create a log directory based on `icingadb_redis_logfile` (#298).

--- a/roles/icingadb_redis/tasks/install_on_debian.yml
+++ b/roles/icingadb_redis/tasks/install_on_debian.yml
@@ -4,3 +4,13 @@
     name: "{{ item }}"
     state: present
   loop: "{{ icingadb_redis_packages }}"
+
+- name: Debian - Ensure log directory exists
+  when:
+    - icingadb_redis_logfile != ""
+  ansible.builtin.file:
+    path: "{{ icingadb_redis_logfile | dirname }}"
+    state: directory
+    owner: "{{ icingadb_redis_user }}"
+    group: "adm"
+    mode: "2750"

--- a/roles/icingadb_redis/tasks/install_on_redhat.yml
+++ b/roles/icingadb_redis/tasks/install_on_redhat.yml
@@ -4,3 +4,13 @@
     name: "{{ item }}"
     state: present
   loop: "{{ icingadb_redis_packages }}"
+
+- name: RedHat - Ensure log directory exists
+  when:
+    - icingadb_redis_logfile != ""
+  ansible.builtin.file:
+    path: "{{ icingadb_redis_logfile | dirname }}"
+    state: directory
+    owner: "{{ icingadb_redis_user }}"
+    group: "{{ icingadb_redis_user }}"
+    mode: "0750"

--- a/roles/icingadb_redis/tasks/install_on_suse.yml
+++ b/roles/icingadb_redis/tasks/install_on_suse.yml
@@ -3,3 +3,13 @@
   community.general.zypper:
     name: "{{ icingadb_redis_packages }}"
     state: present
+
+- name: Suse - Ensure log directory exists
+  when:
+    - icingadb_redis_logfile != ""
+  ansible.builtin.file:
+    path: "{{ icingadb_redis_logfile | dirname }}"
+    state: directory
+    owner: "{{ icingadb_redis_user }}"
+    group: "{{ icingadb_redis_user }}"
+    mode: "0750"

--- a/roles/icingadb_redis/templates/icingadb-redis.conf.j2
+++ b/roles/icingadb_redis/templates/icingadb-redis.conf.j2
@@ -13,7 +13,7 @@ tcp-keepalive {{ icingadb_redis_tcp_keepalive }}
 supervised {{ icingadb_redis_supervised }}
 pidfile {{ icingadb_redis_pidfile }}
 loglevel {{ icingadb_redis_loglevel }}
-logfile {{ icingadb_redis_logfile }}
+logfile "{{ icingadb_redis_logfile }}"
 # syslog-enabled no
 # syslog-ident redis
 # syslog-facility local0


### PR DESCRIPTION
Icinga's packages no longer create /var/log/icingadb-redis/ since logging moved to the journal by default. If logging to a file is needed, the according directory has to be created beforehand.

Fixes #298