### PR TITLE
Fix mysql database import for module x509

### DIFF
--- a/changelogs/fragments/fix_issue_303_x509_mysql_import.yml
+++ b/changelogs/fragments/fix_issue_303_x509_mysql_import.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Fixed incorrect failure of x509 variable sanity checks. They now fail as intended instead of due to syntax (#303)."
+  - "Fixed wrong variable being referenced to apply x509 mysql database schema. Use `schema_path_mysql` now (#303)."

--- a/doc/role-icingaweb2/module-x509.md
+++ b/doc/role-icingaweb2/module-x509.md
@@ -68,6 +68,7 @@ To import the database schema use `database` dictionary with the following varia
 | Variable | Type | Description | Default |
 |----------|------|-------------|---------|
 | `import_schema` | `Boolean` | Defines wether the schema will be imported or not. | false |
+| `type` | `String` | Defines the type of database (`mysql \| pgsql`) | **n/a** |
 | `host` | `String` | Defines database address to connect to. | `localhost` |
 | `port` | `int` | Defines the database port to connect to. | `3306` or `5432` |
 | `user` | `string` | Defines database user | `x509` |
@@ -88,6 +89,7 @@ icingaweb2_modules:
     enabled: true
     database:
       import_schema: true
+      type: mysql
       host: localhost
       port: 3306
       user: x509

--- a/roles/icingaweb2/tasks/manage_mysql_imports.yml
+++ b/roles/icingaweb2/tasks/manage_mysql_imports.yml
@@ -33,6 +33,6 @@
 - name: MySQL import  db schema
   ansible.builtin.shell: >
     {{ _tmp_mysqlcmd }}
-    < {{ _db['schema_path'] }}
+    < {{ _db['schema_path_mysql'] }}
   when: _db_schema.rc != 0
   run_once: yes

--- a/roles/icingaweb2/tasks/modules/x509.yml
+++ b/roles/icingaweb2/tasks/modules/x509.yml
@@ -44,12 +44,14 @@
           select_query: "select * from x509_certificate"
           type: "{{ icingaweb2_modules[_module]['database']['type'] | default(omit) }}"
 
-    - ansible.builtin.fail:
-        fail_msg: No database type was provided
+    - name: Module x509 | Check if database type is provided
+      ansible.builtin.fail:
+        msg: No database type was provided
       when: icingaweb2_modules[_module]['database']['type'] is not defined
 
-    - ansible.builtin.fail:
-        fail_msg: "Invalid database type was provided. [Supported: mysql, pgsql]"
+    - name: Module x509 | Check provided database type
+      ansible.builtin.fail:
+        msg: "Invalid database type was provided. [Supported: mysql, pgsql]"
       when: _db.type not in ['mysql', 'pgsql']
 
     - name: Module x509 | Import MySQL Schema


### PR DESCRIPTION
Fixes the automatic import of the x509 database schema using mysql by changing the variable reference `schema_path` to `schema_path_mysql`.

Fixes #303