### PR TITLE
Properly check if vars['icinga2_objects'] is list

### DIFF
--- a/changelogs/fragments/fix_issue_308.yml
+++ b/changelogs/fragments/fix_issue_308.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "The type of :code:`vars['icinga2_objects']` was wrongly tested for. This should be a list. The type is now `properly checked <https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tests.html#type-tests>`_ for (#308)."

--- a/roles/icinga2/tasks/objects.yml
+++ b/roles/icinga2/tasks/objects.yml
@@ -1,14 +1,27 @@
 ---
-- name: collect all config objects for myself
+- name: collect all config objects for myself (from all inventory hosts)
   set_fact:
     tmp_objects: "{{ tmp_objects| default([]) + lookup('list', hostvars[item]['icinga2_objects'][icinga2_config_host]) }}"
   with_items: "{{ groups['all'] }}"
   when: hostvars[item]['icinga2_objects'][icinga2_config_host] is defined
 
+- name: collect all config objects for myself (from myself if list)
+  set_fact:
+    tmp_objects: "{{ tmp_objects | default([]) + lookup('list', hostvars[inventory_hostname]['icinga2_objects']) }}"
+  when:
+    - hostvars[inventory_hostname]['icinga2_objects'] is defined
+    - hostvars[inventory_hostname]['icinga2_objects'] is iterable
+    - hostvars[inventory_hostname]['icinga2_objects'] is not string
+    - hostvars[inventory_hostname]['icinga2_objects'] is not mapping
+
 - name: collect all config objects in play vars
   set_fact:
     tmp_objects: "{{ tmp_objects| default([]) + lookup('list', icinga2_objects) }}"
-  when: icinga2_objects is defined and vars['icinga2_objects'][icinga2_config_host] is not defined
+  when:
+    - icinga2_objects is defined
+    - icinga2_objects is iterable
+    - icinga2_objects is not string
+    - icinga2_objects is not mapping
 
 - icinga2_object:
     args: "{{ item }}"


### PR DESCRIPTION
The previous conditions did not suffice in determining whether vars['icinga2_objects'] was a list or not. Thus the variable was sometimes treated as a list even though it was a dictionary for example. This resulted in task failures.

This commit applies proper checks. Fixes #308.