### PR TITLE
Use double quotes instead of single quotes in ini

### DIFF
--- a/changelogs/fragments/fix_issue_301.yml
+++ b/changelogs/fragments/fix_issue_301.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Certain values within Icinga Web :code:`ini` files got quoted incorrectly using single quotes. They are now quoted properly using double quotes (#301)."

--- a/molecule/ini-configuration-tests/tests/integration/test_ini_config.py
+++ b/molecule/ini-configuration-tests/tests/integration/test_ini_config.py
@@ -20,10 +20,10 @@ def test_advanced_filter(host):
     i2_file = host.file("/tmp/advanced_filter")
     print(i2_file.content_string)
     assert i2_file.is_file
-    assert i2_file.content_string == "\n[section]\ntest = '!(objectClass=user)'\ntest2 = '!(objectClass=user)'\ntest3 = '!attribute'\n"
+    assert i2_file.content_string == '\n[section]\ntest = "!(objectClass=user)"\ntest2 = "!(objectClass=user)"\ntest3 = "!attribute"\n'
 
 def test_equal_sign(host):
     i2_file = host.file("/tmp/equal_sign")
     print(i2_file.content_string)
     assert i2_file.is_file
-    assert i2_file.content_string == "\n[section]\ntest = 'equal=sign'\n"
+    assert i2_file.content_string == '\n[section]\ntest = "equal=sign"\n'

--- a/roles/icingaweb2/templates/ini_template.j2
+++ b/roles/icingaweb2/templates/ini_template.j2
@@ -7,8 +7,8 @@
 {{ option }} = "{{ value }}"
 {% elif value is iterable and (value is not string and value is not mapping) %}
 {{ option }} = "{{ value | join(', ') }}"
-{% elif ( value is string and ( "=" in value or "!" in value ) )%}
-{{ option }} = '{{ value }}'
+{% elif ( value is string and ( "=" in value or "!" in value or " " in value ) )%}
+{{ option }} = "{{ value }}"
 {% else %}
 {{ option }} = {{ value }}
 {% endif %}


### PR DESCRIPTION
Within Icinga Web's ini files double quotes are needed to encapsulate certain values. Changed single quotes to double quotes in template.

Fixes #301