### PR TITLE
Add ability to use nested directories for config

### DIFF
--- a/changelogs/fragments/fix_issue_309.yml
+++ b/changelogs/fragments/fix_issue_309.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "When using :code:`icinga2_custom_config` sub directories within the found :code:`files/` directory can now be used to deploy Icinga 2 configuration. This allows users to freely structure their :code:`files/` directory (nested directories) (#309)."

--- a/roles/icinga2/tasks/objects.yml
+++ b/roles/icinga2/tasks/objects.yml
@@ -39,7 +39,7 @@
   block:
     - name: construct _icinga2_custom_conf_paths
       set_fact:
-        _icinga2_custom_conf_paths: "{{ _icinga2_custom_conf_paths + [ icinga2_fragments_path + '/' + item.path + '/' + item.order|default('20')|string + '_' + item.name] }}"
+        _icinga2_custom_conf_paths: "{{ _icinga2_custom_conf_paths + [ icinga2_fragments_path + '/' + item.path + '/' + item.order|default('20')|string + '_' + (item.name | replace('/', '_'))] }}"
       loop: "{{ icinga2_custom_config }}"
 
     - name: prepare custom config paths
@@ -57,5 +57,5 @@
         group: root
         mode: 0644
         src: "files/{{ item.name }}"
-        dest: "{{ icinga2_fragments_path }}/{{ item.path }}/{{ item.order|default('20')|string }}_{{ item.name }}"
+        dest: "{{ icinga2_fragments_path }}/{{ item.path }}/{{ item.order|default('20')|string }}_{{ item.name | replace('/', '_') }}"
       loop: "{{ icinga2_custom_config }}"


### PR DESCRIPTION
Using `icinga2_custom_config` allows deploying custom configuration files. They are read in from the `files` directory. This change allows for the use of nested directories instead of relying on just one directory level.

Fixes #309