### PR TITLE
Use correct variable for insecure tls connection

### DIFF
--- a/changelogs/fragments/fix_issue_302.yml
+++ b/changelogs/fragments/fix_issue_302.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "The Icinga DB config template used two different variables to configure (in)secure TLS communication with the database. It now uses :code:`icingadb_database_tls_insecure` for both the condition and as the actual value (#302)."

--- a/roles/icingadb/templates/icingadb.ini.j2
+++ b/roles/icingadb/templates/icingadb.ini.j2
@@ -24,7 +24,7 @@ database:
   ca: {{ icingadb_database_ca }}
 {% endif %}
 {% if icingadb_database_tls_insecure is defined %}
-  insecure: {{ icingadb_database_insecure }}
+  insecure: {{ icingadb_database_tls_insecure }}
 {% endif %}
 
 


### PR DESCRIPTION
The value of `icingadb_database_tls_insecure` is meant to be used in the IcingaDB config template if the variable is defined. Prior to this change the condition checked against `icingadb_database_tls_insecure` while the used value was `icingadb_database_insecure`.

Both cases now refer to `icingadb_database_tls_insecure`.

Fixes #302