### PR TITLE
Fix/276 move package variables to defaults

### DIFF
--- a/roles/icinga2/defaults/main.yml
+++ b/roles/icinga2/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+icinga2_packages: ["icinga2"]
 icinga2_state: started
 icinga2_enabled: true
 icinga2_confd: true

--- a/roles/icinga2/tasks/install_on_Debian.yml
+++ b/roles/icinga2/tasks/install_on_Debian.yml
@@ -1,5 +1,5 @@
 ---
 - name: Apt - install package icinga2
   ansible.builtin.apt:
-    pkg: "{{ icinga2_packages }}"
+    pkg: "{{ icinga2_packages + icinga2_packages_dependencies }}"
     state: present

--- a/roles/icinga2/tasks/install_on_RedHat.yml
+++ b/roles/icinga2/tasks/install_on_RedHat.yml
@@ -1,8 +1,8 @@
 - name: Yum - install package icinga2
   ansible.builtin.yum:
-    name: "{{ icinga2_packages }}"
+    name: "{{ icinga2_packages + icinga2_packages_dependencies }}"
     state: present
-    
+
 - name: Yum - install package icinga2-selinux
   ansible.builtin.yum:
     name: icinga2-selinux

--- a/roles/icinga2/tasks/install_on_Suse.yml
+++ b/roles/icinga2/tasks/install_on_Suse.yml
@@ -1,7 +1,7 @@
 ---
 - name: Zypper - install package icinga2
   community.general.zypper:
-    name: "{{ icinga2_packages }}"
+    name: "{{ icinga2_packages + icinga2_packages_dependencies }}"
     state: present
 
 - name: Zypper - install package icinga2-selinux

--- a/roles/icinga2/vars/Debian.yml
+++ b/roles/icinga2/vars/Debian.yml
@@ -1,5 +1,5 @@
 ---
-icinga2_packages: ["icinga2"]
+icinga2_packages_dependencies: []
 icinga2_user: nagios
 icinga2_group: nagios
 icinga2_config_path: /etc/icinga2

--- a/roles/icinga2/vars/RedHat.yml
+++ b/roles/icinga2/vars/RedHat.yml
@@ -1,5 +1,5 @@
 ---
-icinga2_packages: ["icinga2"]
+icinga2_packages_dependencies: []
 icinga2_user: icinga
 icinga2_group: icinga
 icinga2_config_path: /etc/icinga2

--- a/roles/icinga2/vars/Suse-12.yml
+++ b/roles/icinga2/vars/Suse-12.yml
@@ -1,5 +1,5 @@
 ---
-icinga2_packages: ["icinga2","libboost_regex1_54_0"]
+icinga2_packages_dependencies: ["libboost_regex1_54_0"]
 icinga2_user: icinga
 icinga2_group: icinga
 icinga2_config_path: /etc/icinga2

--- a/roles/icinga2/vars/Suse.yml
+++ b/roles/icinga2/vars/Suse.yml
@@ -1,5 +1,5 @@
 ---
-icinga2_packages: ["icinga2","libboost_regex1_66_0"]
+icinga2_packages_dependencies: ["libboost_regex1_66_0"]
 icinga2_user: icinga
 icinga2_group: icinga
 icinga2_config_path: /etc/icinga2

--- a/roles/icingaweb2/README.md
+++ b/roles/icingaweb2/README.md
@@ -1,0 +1,3 @@
+### Workaround Missing README
+
+Issue: https://github.com/ansible/galaxy/issues/2438

--- a/roles/icingaweb2/defaults/main.yml
+++ b/roles/icingaweb2/defaults/main.yml
@@ -1,3 +1,4 @@
+icingaweb2_packages: ["icingaweb2", "icingacli"]
 icingaweb2_config_dir: /etc/icingaweb2
 icingaweb2_group: icingaweb2
 icingaweb2_modules_config_dir: "{{ icingaweb2_config_dir }}/modules"

--- a/roles/icingaweb2/tasks/install_on_debian.yml
+++ b/roles/icingaweb2/tasks/install_on_debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Debian - Install Icinga Web 2 packages
   ansible.builtin.apt:
-    name: "{{ icingaweb2_packages }}"
+    name: "{{ icingaweb2_packages + icingaweb2_packages_dependencies }}"
     state: present
     update_cache: True

--- a/roles/icingaweb2/tasks/install_on_redhat.yml
+++ b/roles/icingaweb2/tasks/install_on_redhat.yml
@@ -1,5 +1,5 @@
 ---
 - name: RedHat - Install Icinga Web 2 packages
   ansible.builtin.yum:
-    name: "{{ icingaweb2_packages }}"
+    name: "{{ icingaweb2_packages + icingaweb2_packages_dependencies }}"
     state: present

--- a/roles/icingaweb2/tasks/install_on_suse.yml
+++ b/roles/icingaweb2/tasks/install_on_suse.yml
@@ -1,5 +1,5 @@
 ---
 - name: Suse - Install Icinga Web 2 packages
   community.general.zypper:
-    name: "{{ icingaweb2_packages }}"
+    name: "{{ icingaweb2_packages + icingaweb2_packages_dependencies }}"
     state: present

--- a/roles/icingaweb2/vars/debian-ubuntu.yml
+++ b/roles/icingaweb2/vars/debian-ubuntu.yml
@@ -1,3 +1,3 @@
 icingaweb2_httpd_user: www-data
 icingaweb2_fragments_path: /var/tmp/icingaweb
-icingaweb2_packages: ["icingaweb2","icingacli","libapache2-mod-php"]
+icingaweb2_packages_dependencies: ["libapache2-mod-php"]

--- a/roles/icingaweb2/vars/debian.yml
+++ b/roles/icingaweb2/vars/debian.yml
@@ -1,3 +1,3 @@
 icingaweb2_httpd_user: www-data
 icingaweb2_fragments_path: /var/tmp/icingaweb
-icingaweb2_packages: ["icingaweb2", "icingacli"]
+icingaweb2_packages_dependencies: []

--- a/roles/icingaweb2/vars/redhat.yml
+++ b/roles/icingaweb2/vars/redhat.yml
@@ -1,4 +1,4 @@
 ---
 icingaweb2_httpd_user: apache
 icingaweb2_fragments_path: /var/tmp/icingaweb
-icingaweb2_packages: ["icingaweb2", "icingacli", "icingaweb2-selinux"]
+icingaweb2_packages_dependencies: ["icingaweb2-selinux"]

--- a/roles/icingaweb2/vars/suse.yml
+++ b/roles/icingaweb2/vars/suse.yml
@@ -1,4 +1,4 @@
 ---
 icingaweb2_httpd_user: wwwrun
 icingaweb2_fragments_path: /var/tmp/icingaweb
-icingaweb2_packages: ["icingaweb2", "icingacli"]
+icingaweb2_packages_dependencies: []


### PR DESCRIPTION
This PR moves the variables `icinga[web]2_packages` to **defaults/main.yml** and adds `icinga[web]2_packages_dependencies` to the os specific files within **vars/**.

This allows for `icinga[web]2_packages` to be changed more easily if required (no Ansible extra vars in CLI or set_fact needed).  
We still keep the option to define additional os specific dependencies (e.g. `icingaweb2-selinux`).

Fixes #276 