### PR TITLE
Add support for Suse in role 'monitoring_plugins'

### DIFF
--- a/changelogs/fragments/feature_monitoring_plugins_suse.yml
+++ b/changelogs/fragments/feature_monitoring_plugins_suse.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add support for Suse in the :code:`monitoring_plugins` role.

--- a/doc/role-monitoring_plugins/check_command_list.md
+++ b/doc/role-monitoring_plugins/check_command_list.md
@@ -1,68 +1,68 @@
 # Available Check Commands
 
-Here is a list of the available check commands and the packages they correspond to for Debian and RedHat based systems.  
+Here is a list of the available check commands and the packages they correspond to for Debian, RedHat and Suse based systems.
 
 Depending on the major version some packages might not be available. For example `nagios-plugins-game` is available using Enterprise Linux **7** and **9** but not using Enterprise Linux **8**.  
-A run will **not** fail because of that. Those requested checks are silently skipped.  
+A run will **not** fail because of that. Those requested checks are silently skipped.
 
-Version specific differences in package names are also accounted for.  
+Version specific differences in package names are also accounted for.
 
-| Check Command Name     | Debian Package              | RedHat Package           |
-| ---                    | ---                         | ---                      |
-| apt                    | monitoring-plugins-basic    | nagios-plugins-apt       |
-| breeze                 | monitoring-plugins-standard | nagios-plugins-breeze    |
-| by_ssh                 | monitoring-plugins-basic    | nagios-plugins-by_ssh    |
-| clamd                  | monitoring-plugins-basic    | nagios-plugins-tcp       |
-| dhcp                   | monitoring-plugins-basic    | nagios-plugins-dhcp      |
-| dig                    | monitoring-plugins-standard | nagios-plugins-dig       |
-| disk                   | monitoring-plugins-basic    | nagios-plugins-disk      |
-| disk_smb               | monitoring-plugins-standard | nagios-plugins-disk_smb  |
-| dns                    | monitoring-plugins-standard | nagios-plugins-dns       |
-| file_age               | monitoring-plugins-basic    | nagios-plugins-file_age  |
-| flexlm                 | monitoring-plugins-standard | nagios-plugins-flexlm    |
-| fping                  | monitoring-plugins-standard | nagios-plugins-fping     |
-| fping4                 | monitoring-plugins-standard | nagios-plugins-fping     |
-| fping6                 | monitoring-plugins-standard | nagios-plugins-fping     |
-| ftp                    | monitoring-plugins-basic    | nagios-plugins-tcp       |
-| game                   | monitoring-plugins-standard | nagios-plugins-game      |
-| hostalive              | monitoring-plugins-basic    | nagios-plugins-ping      |
-| hostalive4             | monitoring-plugins-basic    | nagios-plugins-ping      |
-| hostalive6             | monitoring-plugins-basic    | nagios-plugins-ping      |
-| hpjd                   | monitoring-plugins-standard | nagios-plugins-hpjd      |
-| http                   | monitoring-plugins-basic    | nagios-plugins-http      |
-| icmp                   | monitoring-plugins-basic    | nagios-plugins-icmp      |
-| imap                   | monitoring-plugins-basic    | nagios-plugins-tcp       |
-| ldap                   | monitoring-plugins-standard | nagios-plugins-ldap      |
-| load                   | monitoring-plugins-basic    | nagios-plugins-load      |
-| mailq                  | monitoring-plugins-standard | nagios-plugins-mailq     |
-| mysql                  | monitoring-plugins-standard | nagios-plugins-mysql     |
-| mysql_query            | monitoring-plugins-standard | nagios-plugins-mysql     |
-| negate                 | monitoring-plugins-common   | nagios-plugins           |
-| nrpe                   | nagios-nrpe-plugin          | nagios-plugins-nrpe      |
-| nscp                   | monitoring-plugins-basic    | nagios-plugins-nt        |
-| ntp_peer               | monitoring-plugins-basic    | nagios-plugins-ntp       |
-| ntp_time               | monitoring-plugins-basic    | nagios-plugins-ntp       |
-| pgsql                  | monitoring-plugins-standard | nagios-plugins-pgsql     |
-| ping                   | monitoring-plugins-basic    | nagios-plugins-ping      |
-| ping4                  | monitoring-plugins-basic    | nagios-plugins-ping      |
-| ping6                  | monitoring-plugins-basic    | nagios-plugins-ping      |
-| pop                    | monitoring-plugins-basic    | nagios-plugins-tcp       |
-| procs                  | monitoring-plugins-basic    | nagios-plugins-procs     |
-| radius                 | monitoring-plugins-standard | nagios-plugins-radius    |
-| rpc                    | monitoring-plugins-standard | nagios-plugins-rpc       |
-| simap                  | monitoring-plugins-basic    | nagios-plugins-tcp       |
-| smart                  | monitoring-plugins-basic    | nagios-plugins-ide_smart |
-| smtp                   | monitoring-plugins-basic    | nagios-plugins-smtp      |
-| snmp                   | monitoring-plugins-standard | nagios-plugins-snmp      |
-| snmpv3                 | monitoring-plugins-standard | nagios-plugins-snmp      |
-| snmp-uptime            | monitoring-plugins-standard | nagios-plugins-snmp      |
-| spop                   | monitoring-plugins-basic    | nagios-plugins-tcp       |
-| ssh                    | monitoring-plugins-basic    | nagios-plugins-ssh       |
-| ssl                    | monitoring-plugins-basic    | nagios-plugins-tcp       |
-| ssmtp                  | monitoring-plugins-basic    | nagios-plugins-tcp       |
-| swap                   | monitoring-plugins-basic    | nagios-plugins-swap      |
-| tcp                    | monitoring-plugins-basic    | nagios-plugins-tcp       |
-| udp                    | monitoring-plugins-basic    | nagios-plugins-tcp       |
-| ups                    | monitoring-plugins-basic    | nagios-plugins-ups       |
-| uptime                 | nagios-plugins-contrib      | nagios-plugins-uptime    |
-| users                  | monitoring-plugins-basic    | nagios-plugins-users     |
+| Check Command Name     | Debian Package              | RedHat Package           | Suse Package                 |
+| ---                    | ---                         | ---                      | ---                          |
+| apt                    | monitoring-plugins-basic    | nagios-plugins-apt       | -                            |
+| breeze                 | monitoring-plugins-standard | nagios-plugins-breeze    | monitoring-plugins-breeze    |
+| by_ssh                 | monitoring-plugins-basic    | nagios-plugins-by_ssh    | monitoring-plugins-by_ssh    |
+| clamd                  | monitoring-plugins-basic    | nagios-plugins-tcp       | nagios-plugins-tcp           |
+| dhcp                   | monitoring-plugins-basic    | nagios-plugins-dhcp      | monitoring-plugins-dhcp      |
+| dig                    | monitoring-plugins-standard | nagios-plugins-dig       | monitoring-plugins-dig       |
+| disk                   | monitoring-plugins-basic    | nagios-plugins-disk      | monitoring-plugins-disk      |
+| disk_smb               | monitoring-plugins-standard | nagios-plugins-disk_smb  | monitoring-plugins-disk_smb  |
+| dns                    | monitoring-plugins-standard | nagios-plugins-dns       | monitoring-plugins-dns       |
+| file_age               | monitoring-plugins-basic    | nagios-plugins-file_age  | monitoring-plugins-file_age  |
+| flexlm                 | monitoring-plugins-standard | nagios-plugins-flexlm    | monitoring-plugins-flexlm    |
+| fping                  | monitoring-plugins-standard | nagios-plugins-fping     | monitoring-plugins-fping     |
+| fping4                 | monitoring-plugins-standard | nagios-plugins-fping     | monitoring-plugins-fping     |
+| fping6                 | monitoring-plugins-standard | nagios-plugins-fping     | monitoring-plugins-fping     |
+| ftp                    | monitoring-plugins-basic    | nagios-plugins-tcp       | monitoring-plugins-tcp       |
+| game                   | monitoring-plugins-standard | nagios-plugins-game      | -                            |
+| hostalive              | monitoring-plugins-basic    | nagios-plugins-ping      | monitoring-plugins-ping      |
+| hostalive4             | monitoring-plugins-basic    | nagios-plugins-ping      | monitoring-plugins-ping      |
+| hostalive6             | monitoring-plugins-basic    | nagios-plugins-ping      | monitoring-plugins-ping      |
+| hpjd                   | monitoring-plugins-standard | nagios-plugins-hpjd      | monitoring-plugins-hpjd      |
+| http                   | monitoring-plugins-basic    | nagios-plugins-http      | monitoring-plugins-http      |
+| icmp                   | monitoring-plugins-basic    | nagios-plugins-icmp      | monitoring-plugins-icmp      |
+| imap                   | monitoring-plugins-basic    | nagios-plugins-tcp       | monitoring-plugins-tcp       |
+| ldap                   | monitoring-plugins-standard | nagios-plugins-ldap      | monitoring-plugins-ldap      |
+| load                   | monitoring-plugins-basic    | nagios-plugins-load      | monitoring-plugins-load      |
+| mailq                  | monitoring-plugins-standard | nagios-plugins-mailq     | monitoring-plugins-mailq     |
+| mysql                  | monitoring-plugins-standard | nagios-plugins-mysql     | monitoring-plugins-mysql     |
+| mysql_query            | monitoring-plugins-standard | nagios-plugins-mysql     | monitoring-plugins-mysql     |
+| negate                 | monitoring-plugins-common   | nagios-plugins           | monitoring-plugins-common    |
+| nrpe                   | nagios-nrpe-plugin          | nagios-plugins-nrpe      | monitoring-plugins-nrpe      |
+| nscp                   | monitoring-plugins-basic    | nagios-plugins-nt        | monitoring-plugins-nt        |
+| ntp_peer               | monitoring-plugins-basic    | nagios-plugins-ntp       | monitoring-plugins-ntp_peer  |
+| ntp_time               | monitoring-plugins-basic    | nagios-plugins-ntp       | monitoring-plugins-ntp_time  |
+| pgsql                  | monitoring-plugins-standard | nagios-plugins-pgsql     | monitoring-plugins-pgsql     |
+| ping                   | monitoring-plugins-basic    | nagios-plugins-ping      | monitoring-plugins-ping      |
+| ping4                  | monitoring-plugins-basic    | nagios-plugins-ping      | monitoring-plugins-ping      |
+| ping6                  | monitoring-plugins-basic    | nagios-plugins-ping      | monitoring-plugins-ping      |
+| pop                    | monitoring-plugins-basic    | nagios-plugins-tcp       | monitoring-plugins-tcp       |
+| procs                  | monitoring-plugins-basic    | nagios-plugins-procs     | monitoring-plugins-procs     |
+| radius                 | monitoring-plugins-standard | nagios-plugins-radius    | monitoring-plugins-radius    |
+| rpc                    | monitoring-plugins-standard | nagios-plugins-rpc       | monitoring-plugins-rpc       |
+| simap                  | monitoring-plugins-basic    | nagios-plugins-tcp       | monitoring-plugins-tcp       |
+| smart                  | monitoring-plugins-basic    | nagios-plugins-ide_smart | monitoring-plugins-ide_smart |
+| smtp                   | monitoring-plugins-basic    | nagios-plugins-smtp      | monitoring-plugins-smtp      |
+| snmp                   | monitoring-plugins-standard | nagios-plugins-snmp      | monitoring-plugins-snmp      |
+| snmpv3                 | monitoring-plugins-standard | nagios-plugins-snmp      | monitoring-plugins-snmp      |
+| snmp-uptime            | monitoring-plugins-standard | nagios-plugins-snmp      | monitoring-plugins-snmp      |
+| spop                   | monitoring-plugins-basic    | nagios-plugins-tcp       | monitoring-plugins-tcp       |
+| ssh                    | monitoring-plugins-basic    | nagios-plugins-ssh       | monitoring-plugins-ssh       |
+| ssl                    | monitoring-plugins-basic    | nagios-plugins-tcp       | monitoring-plugins-tcp       |
+| ssmtp                  | monitoring-plugins-basic    | nagios-plugins-tcp       | monitoring-plugins-tcp       |
+| swap                   | monitoring-plugins-basic    | nagios-plugins-swap      | monitoring-plugins-swap      |
+| tcp                    | monitoring-plugins-basic    | nagios-plugins-tcp       | monitoring-plugins-tcp       |
+| udp                    | monitoring-plugins-basic    | nagios-plugins-tcp       | monitoring-plugins-tcp       |
+| ups                    | monitoring-plugins-basic    | nagios-plugins-ups       | monitoring-plugins-ups       |
+| uptime                 | nagios-plugins-contrib      | nagios-plugins-uptime    | monitoring-plugins-uptime    |
+| users                  | monitoring-plugins-basic    | nagios-plugins-users     | monitoring-plugins-users     |

--- a/doc/role-monitoring_plugins/role-monitoring_plugins.md
+++ b/doc/role-monitoring_plugins/role-monitoring_plugins.md
@@ -5,6 +5,8 @@ The list is based on the section *"Plugin Check Commands for Monitoring Plugins"
 
 * [List of available check commands](check_command_list.md)
 
+> For Suse based systems you need the Ansible module `zypper`. Refer to the [getting started](https://github.com/Icinga/ansible-collection-icinga/blob/main/doc/getting-started.md#requirements) section.
+
 ## Variables
 
 - `icinga_monitoring_plugins_epel: boolean`

--- a/roles/monitoring_plugins/tasks/install_on_Suse.yml
+++ b/roles/monitoring_plugins/tasks/install_on_Suse.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Zypper - install requested packages
+  become: yes
+  community.general.zypper:
+    state: present
+    name: "{{ needed_packages }}"
+    update_cache: true
+  register: "zypper_result"
+  changed_when: zypper_result.stdout is defined
+  when:
+    - needed_packages is defined
+    - needed_packages
+
+- name: Zypper - remove non-requested packages
+  become: yes
+  community.general.zypper:
+    state: absent
+    name: "{{ (unwanted_packages | difference(['monitoring-plugins-common'])) if icinga_monitoring_plugins_check_commands else unwanted_packages }}"
+    clean_deps: "{{ icinga_monitoring_plugins_autoremove }}"
+  when:
+    - icinga_monitoring_plugins_remove
+    - unwanted_packages

--- a/roles/monitoring_plugins/vars/Suse.yml
+++ b/roles/monitoring_plugins/vars/Suse.yml
@@ -1,0 +1,123 @@
+---
+
+icinga_monitoring_plugins_available_packages:
+  - name: apt
+    pkg_name: "UNAVAILABLE"
+  - name: breeze
+    pkg_name: "monitoring-plugins-breeze"
+  - name: by_ssh
+    pkg_name: "monitoring-plugins-by_ssh"
+  - name: clamd
+    pkg_name: "nagios-plugins-tcp"
+  - name: dhcp
+    pkg_name: "monitoring-plugins-dhcp"
+  - name: dig
+    pkg_name: "monitoring-plugins-dig"
+  - name: disk
+    pkg_name: "monitoring-plugins-disk"
+  - name: disk_smb
+    pkg_name: "monitoring-plugins-disk_smb"
+  - name: dns
+    pkg_name: "monitoring-plugins-dns"
+  - name: file_age
+    pkg_name: "monitoring-plugins-file_age"
+  - name: flexlm
+    pkg_name: "monitoring-plugins-flexlm"
+  - name: fping
+    pkg_name: "monitoring-plugins-fping"
+  - name: fping4
+    pkg_name: "monitoring-plugins-fping"
+  - name: fping6
+    pkg_name: "monitoring-plugins-fping"
+  - name: ftp
+    pkg_name: "monitoring-plugins-tcp"
+  - name: game
+    pkg_name: "UNAVAILABLE"
+  - name: hostalive
+    pkg_name: "monitoring-plugins-ping"
+  - name: hostalive4
+    pkg_name: "monitoring-plugins-ping"
+  - name: hostalive6
+    pkg_name: "monitoring-plugins-ping"
+  - name: hpjd
+    pkg_name: "monitoring-plugins-hpjd"
+  - name: http
+    pkg_name: "monitoring-plugins-http"
+  - name: icmp
+    pkg_name: "monitoring-plugins-icmp"
+  - name: imap
+    pkg_name: "monitoring-plugins-tcp"
+  - name: ldap
+    pkg_name: "monitoring-plugins-ldap"
+  - name: load
+    pkg_name: "monitoring-plugins-load"
+  - name: mailq
+    pkg_name: "monitoring-plugins-mailq"
+  - name: mysql
+    pkg_name: "monitoring-plugins-mysql"
+  - name: mysql_query
+    pkg_name: "monitoring-plugins-mysql"
+  - name: negate
+    pkg_name: "monitoring-plugins-common"
+  - name: nrpe
+    pkg_name: "monitoring-plugins-nrpe"
+  - name: nscp
+    pkg_name: "monitoring-plugins-nt"
+  - name: ntp_peer
+    pkg_name: "monitoring-plugins-ntp_peer"
+  - name: ntp_time
+    pkg_name: "monitoring-plugins-ntp_time"
+  - name: pgsql
+    pkg_name: "monitoring-plugins-pgsql"
+  - name: ping
+    pkg_name: "monitoring-plugins-ping"
+  - name: ping4
+    pkg_name: "monitoring-plugins-ping"
+  - name: ping6
+    pkg_name: "monitoring-plugins-ping"
+  - name: pop
+    pkg_name: "monitoring-plugins-tcp"
+  - name: procs
+    pkg_name: "monitoring-plugins-procs"
+  - name: radius
+    pkg_name: "monitoring-plugins-radius"
+  - name: rpc
+    pkg_name: "monitoring-plugins-rpc"
+  - name: simap
+    pkg_name: "monitoring-plugins-tcp"
+  - name: smart
+    pkg_name: "monitoring-plugins-ide_smart"
+  - name: smtp
+    pkg_name: "monitoring-plugins-smtp"
+  - name: snmp
+    pkg_name: "monitoring-plugins-snmp"
+  - name: snmpv3
+    pkg_name: "monitoring-plugins-snmp"
+  - name: snmp-uptime
+    pkg_name: "monitoring-plugins-snmp"
+  - name: spop
+    pkg_name: "monitoring-plugins-tcp"
+  - name: ssh
+    pkg_name: "monitoring-plugins-ssh"
+  - name: ssl
+    pkg_name: "monitoring-plugins-tcp"
+  - name: ssmtp
+    pkg_name: "monitoring-plugins-tcp"
+  - name: swap
+    pkg_name: "monitoring-plugins-swap"
+  - name: tcp
+    pkg_name: "monitoring-plugins-tcp"
+  - name: udp
+    pkg_name: "monitoring-plugins-tcp"
+  - name: ups
+    pkg_name: "monitoring-plugins-ups"
+  - name: uptime
+    pkg_name: "monitoring-plugins-uptime"
+  - name: users
+    pkg_name: "monitoring-plugins-users"
+
+icinga_monitoring_plugins_available_packages_exclude:
+  - name: apt
+    pkg_name: "UNAVAILABLE"
+  - name: game
+    pkg_name: "UNAVAILABLE"


### PR DESCRIPTION
This PR adds support for Suse in the role `monitoring_plugins`.

It will help to finish #259.