### PR TITLE
Add color hints to text blocks, use explicit <br> instead of whitespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ This repository uses [Ansible Changelogs Fragments]. A basic changelog fragment 
 
 Each PR must use a new fragment file rather than adding to an existing one, so we can trace the change back to the PR that introduced it. Example:
 
-```
-cat changelogs/fragments/fix_issue_123.yml
+```yaml
+# cat changelogs/fragments/fix_issue_123.yml
 ---
 bugfixes:
   - Fixes issue with something that was caused by something else
@@ -32,7 +32,7 @@ Choosing a proper name for a branch helps us identify its purpose and possibly f
 Generally a branch name should include a topic such as `fix` or `feature` followed by a description and an issue number
 if applicable. Branches should have only changes relevant to a specific issue.
 
-```
+```bash
 git checkout -b fix/service-template-typo-1234
 git checkout -b feature/config-handling-1235
 git checkout -b doc/fix-typo-1236

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -2,62 +2,62 @@
 
 > This is meant as an *internal* note on how to build and publish a new version of this Ansible Collection.
 
-1. **Get the release branch ready:**  
-   Push your local changes to the remote.  
-   From your local release branch:  
-   ```
+1. **Get the release branch ready:**<br>
+   Push your local changes to the remote.<br>
+   From your local release branch:<br>
+   ```bash
    git push --set-upstream origin release/<VERSION>
    ```
 
-   To avoid having leftover files from your local directory end up in the release, please **cleanly clone the release branch to another directory**.  
-   ```
+   To avoid having leftover files from your local directory end up in the release, please **cleanly clone the release branch to another directory**.<br>
+   ```bash
    git clone --branch release/<VERSION> git@github.com:Icinga/ansible-collection-icinga.git release_<VERSION>
    cd release_<VERSION>
    ```
-   You now only have files that were actually commmited.  
+   You now only have files that were actually commmited.<br>
 
-2. **Increase the version number:**  
-   The version of this Collection - as seen by Ansible Galaxy - is determined by **galaxy.yml**.  
-   Increase the version number inside accordingly.   
+2. **Increase the version number:**<br>
+   The version of this Collection - as seen by Ansible Galaxy - is determined by **galaxy.yml**.<br>
+   Increase the version number inside accordingly.<br>
 
-3. **Create a changelog summary:**  
-   This will be shown in the changelog as a short summary for this release.  
+3. **Create a changelog summary:**<br>
+   This will be shown in the changelog as a short summary for this release.<br>
 
-   changelogs/fragments/release_summary.yml:  
-   ```
+   changelogs/fragments/release_summary.yml:<br>
+   ```yaml
    release_summary: |
      Summary text for this release.
      "*Bugfix release*" for example.
    ```
 
-4. **Create a new changelog:**  
-   Lint the changelogs:  
-   ```
+4. **Create a new changelog:**<br>
+   Lint the changelogs:<br>
+   ```bash
    antsibull-changelog lint
    ```
 
-   Generate the changelog:  
-   ```
+   Generate the changelog:<br>
+   ```bash
    antsibull-changelog release --version <VERSION>
    ```
 
    Commit your changes to the release branch.
 
-5. **Build and push to Ansible Galaxy:**  
-   Build a release tar ball (verbose shows skipped files):  
-   ```
+5. **Build and push to Ansible Galaxy:**<br>
+   Build a release tar ball (verbose shows skipped files):<br>
+   ```bash
    ansible-galaxy collection build -vvv
    ```
 
-   Push to Ansible Galaxy:  
-   ```
+   Push to Ansible Galaxy:<br>
+   ```bash
    ansible-galaxy collection publish --token <TOKEN> icinga-icinga-<VERSION>.tar.gz
    ```
-   > This might show errors which does **not** necessarily mean that it failed.  
+   > This might show errors which does **not** necessarily mean that it failed.<br>
    > Have a look at [Ansible Galaxy](https://galaxy.ansible.com/ui/repo/published/icinga/icinga/) and confirm if the release could be published.
 
-6. **Create a release on GitHub:**  
-   When [creating a new release](https://github.com/Icinga/ansible-collection-icinga/releases/new)  
+6. **Create a release on GitHub:**<br>
+   When [creating a new release](https://github.com/Icinga/ansible-collection-icinga/releases/new)<br>
 
    - choose \<VERSION\> as tag
    - choose the branch "release/\<VERSION\>" as target (will be tagged)

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Collection to setup and manage components of the Icinga software stack.
 
 You can easily install the collection with the `ansible-galaxy` command.
 
-```
+```bash
 ansible-galaxy collection install icinga.icinga
 ```
 
 Or if you are using Tower or AWX add the collection to your requirements file.
 
-```
+```yaml
 collections:
   - name: icinga.icinga
 ```
@@ -38,7 +38,7 @@ collections:
 
 To use the collection in your playbooks, add the collection and then use the roles.
 
-```
+```yaml
 - hosts: icinga-server
   roles:
     - icinga.icinga.repos

--- a/TESTING.md
+++ b/TESTING.md
@@ -17,18 +17,23 @@ ini files.
 
 Make sure the following tools are available before start testing with the collection.
 
-```
+```bash
 pip install ansible-core ansible-lint molecule pytest-testinfra
 ```
 
 To test roles locally without docker/service issues, we created a molecule test
 with vagrant. Then you need to install [vagrant](link/to/vagrant) and the molecule plugin.
 
-`pip install molecule-plugins[vagrant]`
+```bash
+pip install molecule-plugins[vagrant]
+```
 
 To use molecule with docker install the docker plugin.
 
-`pip install molecule-plugins[docker]`
+```bash
+pip install molecule-plugins[docker]
+```
+
 
 ### Roles Testing
 
@@ -36,14 +41,18 @@ To test roles over vagrant locally, it is the easiest to run the **local-default
 scenario. The local-default is very big and long running. For shorter tests use
 the role-<rolename> scenarios.
 
-`molecule test -s local-default`
+```bash
+molecule test -s local-default
+```
 
 The following tests are inplemented based on docker. Per default a **ubuntu2204**
 image from geerlingguy's container is used. Thanks [@geerlingguy Dockerhublink](https://hub.docker.com/u/geerlingguy)
 
 To test other distros use the command with the env **MOLECULE_DISTRO**.
 
-`MOLECULE_DISTRO=opensuseleap15 molecule test -s role-icingadb_redis`
+```bash
+MOLECULE_DISTRO=opensuseleap15 molecule test -s role-icingadb_redis
+```
 
 ### Templating Tests
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -46,18 +46,18 @@ To start with the collection, easily install it with the **ansible-galaxy** comm
 
 Installation from Galaxy Server:
 
-```
+```bash
 ansible-galaxy collection install icinga.icinga
 ```
 
 Or pull the collection from the git. (Only useable with Ansible version 2.10.9)
-```
+```bash
 ansible-galaxy collection install git+https://github.com/Icinga/ansible-collection-icinga.git,0.3.0
 ```
 
 Pre 2.10 you can also clone the repository, manually build and install the collection.
 
-```
+```bash
 git clone https://github.com/Icinga/ansible-collection-icinga.git
 ansible-galaxy collection build ansible-collection-icinga
 ansible-galaxy collection install icinga-icinga-0.3.0.tar.gz
@@ -97,7 +97,7 @@ Icinga2 relies on relational databases for many parts of its functionality. **No
 
 This is an example on how to install an Icinga 2 server/master instance.
 
-```
+```yaml
 - name: install icinga2 master
   hosts: master
   vars:
@@ -143,7 +143,7 @@ This is an example on how to install an Icinga 2 server/master instance.
 
 This is an example on how to install an Icinga 2 agent instance.
 
-```
+```yaml
 - name: install icinga2 agent
   hosts: agent
   vars:
@@ -151,7 +151,7 @@ This is an example on how to install an Icinga 2 agent instance.
     icinga2_purge_features: yes # Ansible will manage all features
     icinga2_features:
       - name: api           # Enable Feature API
-        ca_host: master.localdomain      
+        ca_host: master.localdomain
         # Trusted Cert and Ticket will be gathered from this host.
         # Ticket will be "delegated" if the FQDN is not in your Ansible environment
         # use the variable icinga2_delegate_host in addition.
@@ -171,7 +171,7 @@ This is an example on how to install an Icinga 2 agent instance.
 
 This is a example on how to install Icinga 2 server with Icinga Web 2 and Icinga DB.
 
-```
+```yaml
 - name: Converge
   hosts: all
   vars:

--- a/doc/plugins/inventory/icinga-inventory-plugin.md
+++ b/doc/plugins/inventory/icinga-inventory-plugin.md
@@ -332,7 +332,7 @@ Default: `None`
 
 **filters**
 
-The `filters` variable allows for filtering the Icinga 2 hosts to be used within Ansible. In the background [Icinga 2 API filters](https://icinga.com/docs/icinga-2/latest/doc/12-icinga2-api/#filters) are used.
+The `filters` variable allows for filtering the Icinga 2 hosts to be used within Ansible. In the background [Icinga 2 API filters](https://icinga.com/docs/icinga-2/latest/doc/12-icinga2-api/#filters) are used.<br>
 Options for the `filters` variable are explained in [their own section](#filter-options).
 
 ---

--- a/doc/plugins/inventory/icinga-inventory-plugin.md
+++ b/doc/plugins/inventory/icinga-inventory-plugin.md
@@ -264,8 +264,8 @@ The form is `namespace.collection_name.plugin_name`.
 
 This must be `icinga.icinga.icinga`
 
-Required: `true`<br><br>
-Type: `string`<br><br>
+Required: `true`<br>
+Type: `string`<br>
 Default: `None`
 
 ---

--- a/doc/plugins/inventory/icinga-inventory-plugin.md
+++ b/doc/plugins/inventory/icinga-inventory-plugin.md
@@ -5,7 +5,7 @@
 - [Using Constructed Inventory and Cache](#using-constructed-inventory-and-cache)
 - [Filter Options](#filter-options)
 
-There is a lot of Ansible Inventory Plugins to pull host information from different sources. This allows for dynamic inventories that adapt to changes made in other applications.  
+There is a lot of Ansible Inventory Plugins to pull host information from different sources. This allows for dynamic inventories that adapt to changes made in other applications.<br>
 Using this plugin you can use Icinga 2's API to build your Ansible Inventory.
 
 For this to work you need to create a file ending in either `icinga.yml` or `icinga.yaml` and fill it with all required variables to fetch information from your Icinga 2 API.
@@ -16,18 +16,18 @@ Example:
 
 **inventory-icinga.yml:**
 
-```
+```yaml
 ---
 plugin: icinga.icinga.icinga
 user: api-user
 password: api-user-password
 ```
 
-```
+```bash
 ansible -i inventory-icinga.yml localhost -m debug -a "msg='{{ groups }}'"
 ```
 
-```
+```yaml
 localhost | SUCCESS => {
     "msg": {
         "all": [
@@ -63,11 +63,11 @@ localhost | SUCCESS => {
 
 Variables of host `icinga-master`:
 
-```
+```bash
 ansible -i inventory-icinga.yml localhost -m debug -a "msg='{{ hostvars[\"icinga-master\"] }}'"
 ```
 
-```
+```yaml
 icinga-master | SUCCESS => {
     "msg": {
         "ansible_check_mode": false,
@@ -259,13 +259,13 @@ This inventory plugin needs
 
 **plugin**
 
-This is a token that ensures that the plugin definitions are meant for this inventory plugin.  
+This is a token that ensures that the plugin definitions are meant for this inventory plugin.<br>
 The form is `namespace.collection_name.plugin_name`.
 
 This must be `icinga.icinga.icinga`
 
-Required: `true`  
-Type: `string`  
+Required: `true`<br><br>
+Type: `string`<br><br>
 Default: `None`
 
 ---
@@ -274,8 +274,8 @@ Default: `None`
 
 The url to be used for API requests.
 
-Required: `false`  
-Type: `string`  
+Required: `false`<br>
+Type: `string`<br>
 Default: `https://localhost`
 
 ---
@@ -284,8 +284,8 @@ Default: `https://localhost`
 
 The port used by Icinga 2.
 
-Required: `false`  
-Type: `int`  
+Required: `false`<br>
+Type: `int`<br>
 Default: `5665`
 
 ---
@@ -294,8 +294,8 @@ Default: `5665`
 
 The username to be used for API requests.
 
-Required: `true`  
-Type: `string`  
+Required: `true`<br>
+Type: `string`<br>
 Default: `None`
 
 ---
@@ -304,8 +304,8 @@ Default: `None`
 
 The password to be used for API requests.
 
-Required: `true`  
-Type: `string`  
+Required: `true`<br>
+Type: `string`<br>
 Default: `None`
 
 ---
@@ -314,8 +314,8 @@ Default: `None`
 
 Whether the certificates received when requesting the API should be validated to establish trust.
 
-Required: `false`  
-Type: `bool`  
+Required: `false`<br>
+Type: `bool`<br>
 Default: `true`
 
 ---
@@ -324,28 +324,28 @@ Default: `true`
 
 You may decide to define the username for Ansible to connect as within your Icinga 2 host object. This allows the inventory to dynamically adapt the Ansible variable `ansible_user`.
 
-Required: `false`  
-Type: `string`  
+Required: `false`<br>
+Type: `string`<br>
 Default: `None`
 
 ---
 
 **filters**
 
-The `filters` variable allows for filtering the Icinga 2 hosts to be used within Ansible. In the background [Icinga 2 API filters](https://icinga.com/docs/icinga-2/latest/doc/12-icinga2-api/#filters) are used.  
+The `filters` variable allows for filtering the Icinga 2 hosts to be used within Ansible. In the background [Icinga 2 API filters](https://icinga.com/docs/icinga-2/latest/doc/12-icinga2-api/#filters) are used.
 Options for the `filters` variable are explained in [their own section](#filter-options).
 
 ---
 
 **group_prefix**
 
-The inventory plugin automatically builds Ansible groups based on the Icinga 2 host object attributes `groups` and `zone`.  
+The inventory plugin automatically builds Ansible groups based on the Icinga 2 host object attributes `groups` and `zone`.<br>
 This prefix is used as a prefix for those groups within Ansible.
 
 By default groups will be prefixed with `icinga_group_` and `icinga_zone_` respectively.
 
-Required: `false`  
-Type: `string`  
+Required: `false`<br>
+Type: `string`<br>
 Default: `icinga_`
 
 ---
@@ -353,24 +353,24 @@ Default: `icinga_`
 
 **want_ipv4**
 
-It is common practice to set an Icinga 2 host's name equal to its FQDN. This way DNS is the source of truth. But you may want to use a host's IP address for connections made by Ansible.  
-If `want_ipv4` is true, the Ansible variable `ansible_host` will be set to the Icinga host's `address` attribute if applicable.  
+It is common practice to set an Icinga 2 host's name equal to its FQDN. This way DNS is the source of truth. But you may want to use a host's IP address for connections made by Ansible.<br>
+If `want_ipv4` is true, the Ansible variable `ansible_host` will be set to the Icinga host's `address` attribute if applicable.<br>
 `want_ipv4` takes precedence over `want_ipv6`.
 
-Required: `false`  
-Type: `bool`  
+Required: `false`<br>
+Type: `bool`<br>
 Default: `false`
 
 ---
 
 **want_ipv6**
 
-Analogous to `want_ipv4` you may want to use a Icinga host's `address6` attribute to establish connections using Ansible.  
-If `want_ipv6` is true, the Ansible variable `ansible_host` will be set to the Icinga host's `address6` attribute if applicable.  
+Analogous to `want_ipv4` you may want to use a Icinga host's `address6` attribute to establish connections using Ansible.<br>
+If `want_ipv6` is true, the Ansible variable `ansible_host` will be set to the Icinga host's `address6` attribute if applicable.<br>
 `want_ipv4` takes precedence over `want_ipv6`.
 
-Required: `false`  
-Type: `bool`  
+Required: `false`<br>
+Type: `bool`<br>
 Default: `false`
 
 ---
@@ -379,22 +379,22 @@ Default: `false`
 
 All attributes of an Icinga 2 host will be used as host variables within Ansible. Those variables are prefixed with the `vars_prefix`.
 
-Required: `false`  
-Type: `string`  
+Required: `false`<br>
+Type: `string`<br>
 Default: `icinga_`
 
 ---
 
 ## Using Constructed Inventory and Cache
 
-Other than the variables used for this plugin explicitly, you can also make use of some options offered by Ansible's Inventory Module [**Constructed**](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/constructed_inventory.html).  
+Other than the variables used for this plugin explicitly, you can also make use of some options offered by Ansible's Inventory Module [**Constructed**](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/constructed_inventory.html).<br>
 Specifically `keyed_groups` might be useful. This allows you to build new Ansible groups based on Icinga host attributes, e.g. `vars["operating_system"]`.
 
 Example:
 
 **inventory-icinga.yml:**
 
-```
+```yaml
 ---
 plugin: icinga.icinga.icinga
 user: api-user
@@ -409,11 +409,11 @@ keyed_groups:
     key: vars["operating_system"]
 ```
 
-```
+```bash
 ansible -i inventory-icinga.yml localhost -m debug -a "msg='{{ groups }}'"
 ```
 
-```
+```yaml
 localhost | SUCCESS => {
     "msg": {
         "all": [
@@ -466,10 +466,10 @@ localhost | SUCCESS => {
 
 ---
 
-In order to minimize API queries made against Icinga you might want to use cache and retrieve host information this way.  
+In order to minimize API queries made against Icinga you might want to use cache and retrieve host information this way.<br>
 The following is an example on how to use the Ansible builtin cache plugin `jsonfile`.
 
-```
+```yaml
 ---
 plugin: icinga.icinga.icinga
 user: api-user
@@ -491,7 +491,7 @@ If cache is used and the cache is valid, no API calls are made.
 
 ## Filter Options
 
-You might want to restrict which hosts are part of the API query result. You can for example choose to only fetch host information for hosts within a specific Icinga zone.  
+You might want to restrict which hosts are part of the API query result. You can for example choose to only fetch host information for hosts within a specific Icinga zone.<br>
 If you use custom variables like e.g. *'operating_system'* to distinguish between different operating systems, you can use those variables to narrow down the results.
 
 Valid subkeys for `filters` are
@@ -501,8 +501,8 @@ Valid subkeys for `filters` are
 - custom
 - vars
 
-The subkeys 'name', 'group' and 'zone' are meant as defaults that allow for quick filtering based on those Icinga host attributes.  
-Internally Icinga's '**match**' filter is used for 'name' and 'zone'. This way string and boolean comparisons can be made while also allowing for pattern matching.  
+The subkeys 'name', 'group' and 'zone' are meant as defaults that allow for quick filtering based on those Icinga host attributes.<br>
+Internally Icinga's '**match**' filter is used for 'name' and 'zone'. This way string and boolean comparisons can be made while also allowing for pattern matching.<br>
 'group' uses the '**in**' filter to check membership.
 
 The following example shows filters to restrict the result to hosts
@@ -518,9 +518,9 @@ Using CURL:
 curl -k -u 'api-user':'api-user-password' -H 'X-HTTP-Method-Override: GET' -X POST https://localhost:5665/v1/objects/hosts -d '{ "filter": "((match(\"main\", host.zone)||match(\"satellite\", host.zone)))&&((match(\"dummy*\", host.name)))&&(((\"linux_hosts\" in host.groups)))" }'
 ```
 
-Using the plugin: 
+Using the plugin:
 
-```
+```yaml
 ---
 plugin: icinga.icinga.icinga
 user: api-user
@@ -536,14 +536,14 @@ filters:
     - linux_hosts
 ```
 
-In general, all subkeys of `filters` have to evaluate to true **simultaneously**. In the example above 'zone', 'name' and 'group' **must** all match.  
+In general, all subkeys of `filters` have to evaluate to true **simultaneously**. In the example above 'zone', 'name' and 'group' **must** all match.<br>
 Within one of those filter options **only one** of the list's elements must match.
 
 It is also possible to negate entries. In that case **either** entry in the list has to match while **neither** of the negated entries is allowed to match.
 
 To illustrate the logic, we will use 'group' as an example.
 
-```
+```yaml
 group:
   - 'linux_hosts'
   - 'windows_hosts'
@@ -555,15 +555,15 @@ Logically this results in: ( in group 'linux_hosts' **OR** in group 'windows_hos
 
 ---
 
-The 'custom' option lets you simply supply your own filter as it would be passed with CURL (`'{ "filter": "YOUR CUSTOM FILTER" }'`).  
+The 'custom' option lets you simply supply your own filter as it would be passed with CURL (`'{ "filter": "YOUR CUSTOM FILTER" }'`).<br>
 Supplying multiple filters will use logic AND to combine them.
 
-The last subkey you can use is 'vars'. It behaves slightly differently since one cannot anticipate the variables other people might use.  
+The last subkey you can use is 'vars'. It behaves slightly differently since one cannot anticipate the variables other people might use.<br>
 Therefore you have to manually decide on the filter and the custom variable to be used.
 
 Currently the '**match**', '**in**' and '**is**' filters are supported. As before all their subkeys have to match with only one entry that has to match while none of the negated entries are allowed to match.
 
-The '**is**' is filter is special in that regard that here you are supposed to only pass one value to it. If multiple values are passed, only the first value in the list will be used.  
+The '**is**' is filter is special in that regard that here you are supposed to only pass one value to it. If multiple values are passed, only the first value in the list will be used.<br>
 Also, negation is only allowed for 'set' and 'null' using the '**is**' filter.
 
 The following values are accepted:
@@ -578,7 +578,7 @@ The value 'set' allows to check if the value of variable either evaluates to `tr
 
 Example:
 
-```
+```yaml
 ---
 plugin: icinga.icinga.icinga
 user: api-user

--- a/doc/role-icinga2/features.md
+++ b/doc/role-icinga2/features.md
@@ -23,7 +23,7 @@ Current supported features:
 * [Feature notification](features/feature-notification.md)
 * [Feature perfdata](features/feature-perfdata.md)
 
-```
+```yaml
 icinga2_features:
   - name: checker
   - name: mainlog

--- a/doc/role-icinga2/features/feature-api.md
+++ b/doc/role-icinga2/features/feature-api.md
@@ -10,7 +10,7 @@ All non Icinga attributes to configure the feature are explained below.
 
 Example how to install an Agent:
 
-```
+```yaml
 icinga2_features:
   - name: api
     force_newcert: false
@@ -25,7 +25,7 @@ icinga2_features:
 
 Example how to install a master/server instance:
 
-```
+```yaml
 icinga2_features:
   - name: api
     force_newcert: false
@@ -42,7 +42,7 @@ icinga2_features:
 
 To create an instance with a local CA, the API Feature parameter `ca_host` should be `none`.
 
-```
+```yaml
 ca_host: none
 ```
 
@@ -77,7 +77,7 @@ icinga2_features:
 icinga2_delegate_host: icinga-satellite.localdomain
 ```
 Example if agent should connect to satellite and the tickets are generated on the
-master host. 
+master host.
 
 ```yaml
 icinga2_features:
@@ -91,19 +91,19 @@ icinga2_delegate_host: icinga-master.localdomain
 By default the FQDN is used as certificate common name, to put a name
 yourself:
 
-```
+```yaml
 cert_name: myown-commonname.fqdn
 ```
 
 To force a new request set `force_newcert` to `true`:
 
-```
+```yaml
 force_newcert: true
 ```
 
 To increase your security set `ca_fingerprint` to validate the certificate of the `ca_host`:
 
-```
+```yaml
 ca_fingerprint: "00 DE AD BE EF"
 # alternatively
 ca_fingerprint: "00:DE:AD:BE:EF"
@@ -113,7 +113,7 @@ ca_fingerprint: "00 de ad be ef"
 
 The fingerprint can be retrieved with OpenSSL:
 
-```
+```bash
 openssl x509 -noout -fingerprint -sha256 -inform pem -in /path/to/ca.crt
 ```
 
@@ -122,7 +122,7 @@ openssl x509 -noout -fingerprint -sha256 -inform pem -in /path/to/ca.crt
 If you want to use certificates which aren't created by **Icinga 2 CA**, then use
 the following variables to point the role to your own certificates.
 
-```
+```yaml
 ssl_cacert: ca.crt
 ssl_cert: certificate.crt
 ssl_key: certificate.key
@@ -135,7 +135,7 @@ The role will copy the files from your Ansible controller node to
 **/var/lib/icinga2/certs** on the remote host. File names are
 set to by the parameter `cert_name` (by default FQDN).
 
-```
+```yaml
 icinga2_features:
   - name: api
     cert_name: host.example.org
@@ -171,7 +171,7 @@ icinga2_features:
   * Path to the certificate key file when using manual certificates.
 
 * `endpoints: list of dicts`
-  * Defines endpoints in **zones.conf**, each endpoint is required to have a name and optional a host or port.  
+  * Defines endpoints in **zones.conf**, each endpoint is required to have a name and optional a host or port.<br>
     * `name: string`
     * `host: string`
     * `port: number`

--- a/doc/role-icinga2/features/feature-command.md
+++ b/doc/role-icinga2/features/feature-command.md
@@ -4,7 +4,7 @@ To enable the feature command use the following block in the variable `icinga2_f
 
 **INFO** For detailed information and instructions see the Icinga 2 Docs. [Feature Command](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#externalcommandlistener)
 
-```
+```yaml
 icinga2_features:
   - name: command
     state: present

--- a/doc/role-icinga2/features/feature-elasticsearch.md
+++ b/doc/role-icinga2/features/feature-elasticsearch.md
@@ -4,7 +4,7 @@ To enable the feature Elasticsearch use the following block in the variable `ici
 
 **INFO** For detailed information and instructions see the Icinga 2 Docs. [Feature ElasticsearchWriter](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#elasticsearchwriter)
 
-```
+```yaml
 icinga2_features:
   - name: elasticsearch
     host: localhost
@@ -45,7 +45,7 @@ icinga2_features:
   * Whether to use a TLS stream. Defaults to false. Requires an HTTP proxy.
 
 * `insecure_noverify: boolean`
-  * Disable TLS peer verification. 
+  * Disable TLS peer verification.
 
 * `ca_path: string`
   * Path to CA certificate to validate the remote host. Requires enable_tls set to true.
@@ -58,4 +58,3 @@ icinga2_features:
 
 * `enable_ha: boolean`
   * Whether to send warn, crit, min & max tagged data.
-

--- a/doc/role-icinga2/features/feature-gelf.md
+++ b/doc/role-icinga2/features/feature-gelf.md
@@ -4,7 +4,7 @@ To enable the feature GELF use the following block in the variable `icinga2_feat
 
 **INFO** For detailed information and instructions see the Icinga 2 Docs. [Feature GelfWriter](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#gelfwriter)
 
-```
+```yaml
 icinga2_features:
   - name: gelf
     host: localhost
@@ -42,4 +42,3 @@ icinga2_features:
 
 * `key_path: string`
   * Path to host key to accompany the cert_path. Requires enable_tls set to true.
-

--- a/doc/role-icinga2/features/feature-graphite.md
+++ b/doc/role-icinga2/features/feature-graphite.md
@@ -4,7 +4,7 @@ To enable the feature Graphite use the following block in the variable `icinga2_
 
 **INFO** For detailed information and instructions see the Icinga 2 Docs. [Feature GraphiteWriter](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#graphitewriter)
 
-```
+```yaml
 icinga2_features:
   - name: graphite
     host: localhost
@@ -26,16 +26,10 @@ icinga2_features:
   * Metric prefix for service name. Defaults to icinga2.$host.name$.services.$service.name$.$service.check_command$.
 
 * `enable_send_thresholds: boolean`
-  * Send additional threshold metrics. Defaults to false. 
+  * Send additional threshold metrics. Defaults to false.
 
 * `enable_send_metadata: boolean`
   * Send additional metadata metrics. Defaults to false.
 
 * `enable_ha: boolean`
   * Enable the high availability functionality. Only valid in a cluster setup. Defaults to false.
-
-
-
-
-
-

--- a/doc/role-icinga2/features/feature-icingadb.md
+++ b/doc/role-icinga2/features/feature-icingadb.md
@@ -4,7 +4,7 @@ To enable the feature icingadb use the following block in the variable `icinga2_
 
 **INFO** For detailed information and instructions see the Icinga 2 Docs. [Feature IcingaDB](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#icingadb)
 
-```
+```yaml
 icinga2_features:
   - name: icingadb
     host: localhost
@@ -51,4 +51,3 @@ icinga2_features:
 
 * `connect_timeout: int`
   * Timeout for establishing new connections. Within this time, the TCP, TLS (if enabled) and Redis handshakes must complete. Defaults to 15s.
-

--- a/doc/role-icinga2/features/feature-ido.md
+++ b/doc/role-icinga2/features/feature-ido.md
@@ -14,7 +14,7 @@ All other keys are equal to the object type an can be found in the documentation
 
 #### Example MYSQL:
 
-```
+```yaml
 icinga2_features:
   - name: idomysql
     host: localhost
@@ -30,7 +30,7 @@ icinga2_features:
 
 #### Example PGSQL:
 
-```
+```yaml
 icinga2_features:
   - name: idopgsql
     host: localhost
@@ -67,7 +67,7 @@ icinga2_features:
   * Use SSL. Change to true in case you want to use any of the SSL options.
 
 * `ssl_mode: string`
-  * **Only PgSQL**: Enable SSL connection mode. Value must be set according to the sslmode setting: prefer, require, verify-ca, verify-full, allow, disable. 
+  * **Only PgSQL**: Enable SSL connection mode. Value must be set according to the sslmode setting: prefer, require, verify-ca, verify-full, allow, disable.
 
 * `ssl_key: string`
   * SSL client key file path.
@@ -97,7 +97,7 @@ icinga2_features:
   * Description for the Icinga 2 instance.
 
 * `enable_ha: boolean`
-  * Enable the high availability functionality. Only valid in a cluster setup.  
+  * Enable the high availability functionality. Only valid in a cluster setup.
 
 * `failover_timeout: string`
   * Set the failover timeout in a HA cluster. Must not be lower than 30s. Defaults to 30s

--- a/doc/role-icinga2/features/feature-influxdb.md
+++ b/doc/role-icinga2/features/feature-influxdb.md
@@ -4,7 +4,7 @@ To enable the feature InfluxDb use the following block in the variable `icinga2_
 
 **INFO** For detailed information and instructions see the Icinga 2 Docs. [Feature InfluxdbWriter](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#influxdbwriter)
 
-```
+```yaml
 icinga2_features:
   - name: influxdb
     host: localhost
@@ -48,7 +48,7 @@ icinga2_features:
   * Path to CA certificate to validate the remote host.
 
 * `ssl_cert: string`
-  * Path to host certificate to present to the remote host for mutual verification. 
+  * Path to host certificate to present to the remote host for mutual verification.
 
 * `ssl_key: string`
   * Path to host key to accompany the ssl_cert.
@@ -69,8 +69,7 @@ icinga2_features:
   * How long to buffer data points before transferring to InfluxDB. Defaults to 10s.
 
 * `flush_threshold: int`
-  * How many data points to buffer before forcing a transfer to InfluxDB. Defaults to 1024. 
+  * How many data points to buffer before forcing a transfer to InfluxDB. Defaults to 1024.
 
 * `enable_ha: boolean`
   * Enable the high availability functionality. Only valid in a cluster setup. Defaults to false.
-

--- a/doc/role-icinga2/features/feature-influxdb2.md
+++ b/doc/role-icinga2/features/feature-influxdb2.md
@@ -4,7 +4,7 @@ To enable the feature **influxdb2** use the following block in the variable `ici
 
 **INFO** For detailed information and instructions see the Icinga 2 Docs. [Feature Influxdb2Writer](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#influxdb2writer)
 
-```
+```yaml
 icinga2_features:
   - name: influxdb2
     host: localhost

--- a/doc/role-icinga2/features/feature-livestatus.md
+++ b/doc/role-icinga2/features/feature-livestatus.md
@@ -2,7 +2,7 @@
 
 To enable the feature livestatus add the following block to the variable `icinga2_features`.
 
-```
+```yaml
 icinga2_features:
   - name: livestatus
 ```

--- a/doc/role-icinga2/features/feature-mainlog.md
+++ b/doc/role-icinga2/features/feature-mainlog.md
@@ -2,7 +2,7 @@
 
 To enable the feature mainlog add the following block to the variable `icinga2_features`.
 
-```
+```yaml
 icinga2_features:
   - name: mainlog
 ```

--- a/doc/role-icinga2/features/feature-notification.md
+++ b/doc/role-icinga2/features/feature-notification.md
@@ -2,31 +2,30 @@
 
 To activate the feature notification add this block to the variable `icinga2_features`.
 
-```
+```yaml
 icinga2_features:
   - name: notification
 ```
 
 ### Notification Scripts
 
-The role won't manage notifications scripts with the role. Many scripts require dependencies or libraries to be installed. To manage those dependencies create a Ansible role and use it after the Icinga 2 role. 
+The role won't manage notifications scripts with the role. Many scripts require dependencies or libraries to be installed. To manage those dependencies create a Ansible role and use it after the Icinga 2 role.
 
 If there are no dependencies on the script you can easily use the `post_tasks` section in your playbook. Example:
 
-```
+```yaml
 post_tasks:
   - name: copy notifications script
     src: rocket_chat_notification.py
     dest: /etc/icinga2/scripts/rocket_chat_notification.py
     group: "{{ icinga2_group }}
     user: "{{ icinga2_user}}"
-``` 
+```
 
 ### Feature Attributes
 
-* `enable_ha: boolean` 
+* `enable_ha: boolean`
   * Enable the high availability functionality. Only valid in a cluster setup. Disabling this currently only affects reminder notifications.
 
 * `state: string`
   * Decides whether the feature is enabled or disabled. Possible values present, absent.
-

--- a/doc/role-icinga2/features/feature-opentsdb.md
+++ b/doc/role-icinga2/features/feature-opentsdb.md
@@ -4,7 +4,7 @@ To enable the feature OpenTSDB use the following block in the variable `icinga2_
 
 **INFO** For detailed information and instructions see the Icinga 2 Docs. [Feature OpenTsdbWriter](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#opentsdbwriter)
 
-```
+```yaml
 icinga2_features:
   - name: opentsdb
     host: localhost
@@ -30,4 +30,3 @@ icinga2_features:
 
 * `service_template: dictionary`
   * Specify additional tags to be included with service metrics. This requires a sub-dictionary named tags. Also specify a naming prefix by setting metric. More information can be found in OpenTSDB custom tags and OpenTSDB Metric Prefix. Defaults to an empty Dictionary.
-

--- a/doc/role-icinga2/features/feature-perfdata.md
+++ b/doc/role-icinga2/features/feature-perfdata.md
@@ -4,7 +4,7 @@ To enable the feature perfdata use the following block in the variable `icinga2_
 
 **INFO** For detailed information and instructions see the Icinga 2 Docs. [Feature PerfdataWriter](https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#perfdatabwriter)
 
-```
+```yaml
 icinga2_features:
   - name: perfdata
     host_perfdata_path: "/var/spool/icinga2/perfdata/host-perfdata"
@@ -39,4 +39,3 @@ icinga2_features:
 
 * `enable_ha: boolean`
   * Enable the high availability functionality. Only valid in a cluster setup. Defaults to false.
-

--- a/doc/role-icinga2/objects.md
+++ b/doc/role-icinga2/objects.md
@@ -7,8 +7,8 @@ generate configuration files with objects included.
 
 This variable consists of Icinga 2 object attributes and attributes referring to the file created in the process.
 
-> **_NOTE:_** The second level of the dictionary defines on which host the configuration is created. All objects in the example below, will be gathered and deployed on the host.: `host.example.org`.  
-In addition this variable can be logically defined at the **host_vars/agent** and are still deployed on the master **host.example.org**.  
+> **_NOTE:_** The second level of the dictionary defines on which host the configuration is created. All objects in the example below, will be gathered and deployed on the host.: `host.example.org`.<br>
+In addition this variable can be logically defined at the **host_vars/agent** and are still deployed on the master **host.example.org**.<br>
 The second level can **only** be used in **hostvars**!
 
 The `file` key will be used to control in which directory structure the object will be placed.
@@ -19,7 +19,7 @@ The `type` will be the original Icinga 2 object types, a list of all can be foun
 
 ### Icinga2 Objects in Hostvars
 
-When defining `icinga2_objects` as a host specific variable (hostvars/groupvars) you can define the variable as a dictionary. Each dictionary key represents the host on which the key's value will be deployed as configuration.  
+When defining `icinga2_objects` as a host specific variable (hostvars/groupvars) you can define the variable as a dictionary. Each dictionary key represents the host on which the key's value will be deployed as configuration.<br>
 Alternatively you can define `icinga2_objects` as a list which results in the configuration being deployed on just the host for which the variable is defined.
 
 Example defining the variable within hostvars as a dictionary (inventory entry):
@@ -62,12 +62,12 @@ Additionally, the list `icinga2_objects` from within a play's `vars` key will be
 
 ### Icinga2 Objects in Play Vars
 
-If you need to deploy certain Icinga 2 objects on every host in your play, you can define the variable `icinga2_objects` as a list within your play's `vars` key.  
+If you need to deploy certain Icinga 2 objects on every host in your play, you can define the variable `icinga2_objects` as a list within your play's `vars` key.<br>
 This ensures that, **in addition** to the individual host's objects, there is a common set of objects between your hosts.
 
 Example defining the variable within your play's vars:
 
-```
+```yaml
 icinga2_objects:
   - name: "GlobalApiUser"
     type: ApiUser
@@ -88,7 +88,7 @@ More examples at the end -> [Examples](#examples)
 To create or prepare the directories for the monitoring configuration use the variable `icinga2_config_directories`.
 Those directories are only managed when they are part of `zones.d`, `conf.d` or the variable `icinga2_confd`.
 
-```
+```yaml
 icinga2_config_directories:
   - zones.d/main/hosts/
   - zones.d/main/services/
@@ -102,7 +102,7 @@ Ansible controller node and let the role deploy the file to your instance.
 
 Create the custom file below an Ansible **files/** directory and use the variable **icinga2_custom_config**
 
-```
+```yaml
 icinga2_custom_config:
   - name: myown_command.conf
     path: zones.d/main/myown_command.conf
@@ -119,7 +119,7 @@ The parser takes every value in the configuration and decides how the value shou
 
 First of all, to disable the parser use the prefix `-:`.
 
-```
+```yaml
 attr: -:"unparsed quoted string"
 ```
 
@@ -127,7 +127,7 @@ Strings are parsed in chunks, by splitting the original string into separate sub
 
 **NOTICE:** This splitting only works for keywords that are surrounded by whitespace, e.g.:
 
-```
+```yaml
 attr: string1 + string2 - string3
 ```
 
@@ -135,25 +135,25 @@ The algorithm will loop over the parameter and start by splitting it into 'strin
 
 Brackets are parsed for expressions:
 
-```
+```yaml
 attr: 3 * (value1 -  value2) / 2
 ```
 
 The parser also detects function calls and will parse all parameters separately.
 
-```
+```yaml
 attr: function(param1, param2, ...)
 ```
 
 Boolean values can be defined with or without quotes. In addition the Ansible bool types `yes` or `no` can be used either.
 
-```
+```python
 attr: true or attr: 'true'
 ```
 
 To avoid overlapping syntax with Ansible variable syntax, please refer to single quotes `' '` when using own lambda functions in Icinga.
 
-```
+```jinja
 attrs => '{{ ... }}'
 ```
 
@@ -171,24 +171,24 @@ In general all values can be defined without quotes except for lamba functions w
 To replicate Icinga 2 advanced syntax like assignments with `+=` or `-=` you can use the prefix `+` or `-`.
 
 To create the following Icinga 2 DSL syntax,
-```
+```python
 var += config
 ```
 simply use a string with the prefix `+` e.g.
 
-```
+```yaml
 var: `+ config`
 ```
 
 Because of the blank between the `+` and `config` those values are separately parsed and therefore numbers are also possible. For numbers we also can build `-=`, just use the minus sign `-`. This method will work for every attribute or custom attribute.
 
-```
+```python
 attr: + -14 or attr: - -14
 ```
 
 The parser is able to merge or reduce an array. For this method set the first item of your array as `+` or `-` sign.
 
-```
+```yaml
 attr:
   - +
   - item1
@@ -203,7 +203,7 @@ To reduce arrays use the minus sign `-`.
 
 **NOTICE** Please be aware that the minus sign needs to be quoted otherwise the Ansible parser will have troubles reading the array.
 
-```
+```yaml
 attr:
   - '-'
   - item1
@@ -219,7 +219,7 @@ Result in Icinga will be `attr -= [ "item1", "item2", ]`.
 
 To merge dictionaries we can use the plus sign `+`. The plus sign needs to be a key in the dictionary. See following example.
 
-```
+```yaml
 attr:
   +: true
   key1: value1
@@ -227,13 +227,13 @@ attr:
 
 The result:
 
-```
+```ini
 attr["key1"] = "value1"
 ```
 
 The useage of levels in dictionaries aren't limited.
 
-```
+```yaml
 attr:
   key1:
     key2:
@@ -244,7 +244,7 @@ attr:
 
 Result:
 
-```
+```ini
 vars.attr["key1"] = {
     key2 = {
       key3 += {
@@ -258,7 +258,7 @@ vars.attr["key1"] = {
 
 #### Host Template
 
-```
+```yaml
 icinga2_objects:
 [...]
     - name: generic-host
@@ -271,7 +271,7 @@ icinga2_objects:
 
 #### Host
 
-```
+```yaml
 icinga2_objects:
   host.example.org:
     - name: agent.example.org
@@ -289,7 +289,7 @@ icinga2_objects:
 
 #### Host Group
 
-```
+```yaml
 icinga2_objects:
 [...]
     - name: linux-host
@@ -302,7 +302,7 @@ icinga2_objects:
 
 #### Service Template
 
-```
+```yaml
 icinga2_objects:
 [...]
     - name: generic-service
@@ -316,7 +316,7 @@ icinga2_objects:
 
 #### Service Apply
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: ping
@@ -333,7 +333,7 @@ icinga2_objects:
 
 #### Service Apply for
 
-```
+```yaml
 [...]
   - name: ping
     type: Service
@@ -345,7 +345,7 @@ icinga2_objects:
 
 #### Service Object
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: ping6
@@ -359,7 +359,7 @@ icinga2_objects:
 
 #### Service Group
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: service_group_linux
@@ -372,7 +372,7 @@ icinga2_objects:
 
 #### ApiUser
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: icinga-api
@@ -382,12 +382,11 @@ icinga2_objects:
     permissions:
       - "objects/query/Host"
       - "objects/query/Service"
-
 ```
 
 #### TimePeriod
 
-```
+```yaml
 icinga2_objects:
 [...]
 - name: 24x7
@@ -403,7 +402,7 @@ icinga2_objects:
 
 #### Endpoint
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: agent.localdomain
@@ -414,7 +413,7 @@ icinga2_objects:
 
 #### Zone
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: agent.localdomain
@@ -426,7 +425,7 @@ icinga2_objects:
 
 #### ScheduledDowntime
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: webserver_downtime
@@ -443,7 +442,7 @@ icinga2_objects:
 
 #### Notification Template
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: notification-template
@@ -455,7 +454,7 @@ icinga2_objects:
 
 #### Notification
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: notification-to-rhel-host
@@ -474,21 +473,21 @@ icinga2_objects:
 
 #### User
 
- ```
- [...]
-   - name: admin
-     type: User
-     period: "24x7"
-     groups: [ administrators ]
-     email: "icinga@localhost"
-     states: [ OK, Warning, Critical, Unknown ]
-     types: [ Problem, Recovery ]
-     file: zones.d/main/users.conf
- ```
+```yaml
+[...]
+  - name: admin
+    type: User
+    period: "24x7"
+    groups: [ administrators ]
+    email: "icinga@localhost"
+    states: [ OK, Warning, Critical, Unknown ]
+    types: [ Problem, Recovery ]
+    file: zones.d/main/users.conf
+```
 
 #### NotificationCommand
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: service-notification-command
@@ -508,11 +507,11 @@ icinga2_objects:
       notification_address: $address$
       notification_address6: $address6$
       notification_author: $notification.author$
-````
+```
 
 #### UserGroup
 
-```
+```yaml
 [...]
   - name: administrators
     type: UserGroup
@@ -522,7 +521,7 @@ icinga2_objects:
 
 #### CheckCommand
 
-```
+```yaml
 icinga2_objects:
 [...]
   - name: http
@@ -537,7 +536,7 @@ icinga2_objects:
 
 #### Dependency
 
-```
+```yaml
 - name: dependency-to-host
   type: Dependency
   apply: true
@@ -554,7 +553,7 @@ icinga2_objects:
 
 #### EventCommand
 
-```
+```yaml
 - name: restart-httpd-event
   type: EventCommand
   file: zones.d/main/eventcommands.conf

--- a/doc/role-icinga2/role-icinga2.md
+++ b/doc/role-icinga2/role-icinga2.md
@@ -13,7 +13,7 @@ The collection provides several roles to install and configure Icinga 2.
 * `icinga2_constants: dict`
   * Define constants in **constants.conf**, for defaults check the vars folder.
 
-```
+```yaml
 icinga2_constants:
   NodeName: satellite.localdomain
   ZoneName: zone-satellite-d1
@@ -27,7 +27,7 @@ var `icinga2_confd` should be set to `false`.
 Otherwise you can use a directory name to set the include to a different folder
 than **conf.d**. The folder needs to exist below /etc/icinga2. If it should be created by the role use the variable `icinga2_config_directories` in addition.
 
-```
+```yaml
 icinga2_confd: true/false/<directory_name>
 ```
 
@@ -37,7 +37,7 @@ The Icinga 2 role will automatically detect via Ansible facts if SELinux is enab
 
 If the package should be installed, even if SELinux is not enabled or somehow wrongly disabled in Ansible use the following variable.
 
-```
+```yaml
 ansible_selinux:
   status: enabled
 ```
@@ -46,6 +46,6 @@ ansible_selinux:
 
 The role primarily delegates the ticket creation to the [Icinga ca host](features/feature-api.md). If the host is not listed with the same name in Ansible, you can set the name of the host in Ansible with **icinga2_delegate_host**.
 
-```
+```yaml
 icinga2_delegate_host: icinga-master
 ```

--- a/doc/role-icingaweb2/module-businessprocess.md
+++ b/doc/role-icingaweb2/module-businessprocess.md
@@ -11,7 +11,7 @@ For every config file, create a dictionary with sections as keys and the paramet
 
 
 Example:
-```
+```yaml
 icingaweb2_modules:
   businessprocess:
     enabled: true
@@ -25,7 +25,7 @@ Custom process files are a great way to transfer existing business process confi
 To copy existing processes into the processes folder please use the `custom_process_files` dictionary.
 
 The `src_path` will search within any `files/` directory in the Ansible environment.
-```
+```yaml
 icingaweb2_modules:
   businessprocess:
     enabled: true
@@ -33,4 +33,4 @@ icingaweb2_modules:
     custom_process_files:
       - name: test.conf
         src_path: processes/test.conf
-```    
+```

--- a/doc/role-icingaweb2/module-director.md
+++ b/doc/role-icingaweb2/module-director.md
@@ -18,7 +18,7 @@ the resource.
 
 
 
-```
+```yaml
 icingaweb2_modules:
   director:
     enabled: true

--- a/doc/role-icingaweb2/module-icingadb.md
+++ b/doc/role-icingaweb2/module-icingadb.md
@@ -8,7 +8,7 @@ The general module parameter like `enabled` and `source` can be applied here.
 
 For every config file, create a dictionary with sections as keys and the parameters as values. For all parameters please check the [module documentation](https://icinga.com/docs/icinga-db-web/latest/doc/01-About/)
 
-```
+```yaml
 icingaweb2_modules:
   icingadb:
     enabled: true
@@ -35,7 +35,7 @@ icingaweb2_modules:
 
 Please use the following parameters to configure TLS connections. The collection won't manage those certificates, ensure those are deployed beforehand. At the redis section add the following:
 
-```
+```yaml
 redis:
   tls: '1'
   ca: /path/to/ca.crt

--- a/doc/role-icingaweb2/module-monitoring.md
+++ b/doc/role-icingaweb2/module-monitoring.md
@@ -8,7 +8,7 @@ The general module parameter `enabled` be applied here.
 
 For every config file, create a dictionary with sections as keys and the parameters as values. For all parameters please check the [module documentation](https://icinga.com/docs/icinga-web/latest/doc/03-Configuration/#configuration)
 
-```
+```yaml
 icingaweb2_modules:
   monitoring:
     enabled: true

--- a/doc/role-icingaweb2/module-x509.md
+++ b/doc/role-icingaweb2/module-x509.md
@@ -13,7 +13,7 @@ The general module parameter like `enabled` and `source` can be applied here.
 
 The backend database for the module needs to be available and configured at the `icingaweb2_resources` variable.
 
-```
+```yaml
 icingaweb2_modules:
   x509:
     source: package
@@ -29,7 +29,7 @@ To configure SNIs for a IP address, use the dictionary `sni`.
 
 Example:
 
-```
+```yaml
 icingaweb2_modules:
   x509:
     source: package
@@ -49,7 +49,7 @@ icingaweb2_modules:
 To import certificates use the **list** `certificate_files` all files need to be
 available locally beforehand.
 
-```
+```yaml
 icingaweb2_modules:
   x509:
     source: package
@@ -82,7 +82,7 @@ To import the database schema use `database` dictionary with the following varia
 |`ssl_extra_options`|`String`| Extra options for the client authentication. | **n/a** |
 
 
-```
+```yaml
 icingaweb2_modules:
   x509:
     source: package

--- a/doc/role-icingaweb2/role-icingaweb2.md
+++ b/doc/role-icingaweb2/role-icingaweb2.md
@@ -17,7 +17,7 @@ Icingaweb2 and some of its modules rely on a relational database to persist data
 
 If you use this configuration it will be your main Icinga Web DB, this means if the variable `icingaweb2_db_import_schema` is used the schema will be imported to this database.
 
-```
+```yaml
 icingaweb2_db:
   type: mysql
   name: icingaweb
@@ -36,7 +36,7 @@ icingaweb2_db:
 
 Besides the standard Icinga Web 2 database you may configure additional resources for IcingaDB or automated imports.
 
-```
+```yaml
 icingaweb2_resources:
   icinga_ido:
     type: db
@@ -57,7 +57,7 @@ icingaweb2_resources:
 The general configuration of Icinga Web 2 is located at `{{ icingaweb2_config_dir }}/config.ini`.
 To create the file the following variable is used (default):
 
-```
+```yaml
 icingaweb2_config:
   global:
     show_stacktraces: 1
@@ -83,7 +83,7 @@ Explained:
 
 So the above YAML results in:
 
-```
+```ini
 [global]
 show_stacktraces = "1"
 show_application_state_messages = "1"
@@ -104,10 +104,10 @@ For more information about the general configuration have a look at the [officia
 
 ### Authentication
 
-At least one method of user authentication needs to be configured in order to use Icinga Web 2. This is achieved by defining `icingaweb2_authentication`.  
+At least one method of user authentication needs to be configured in order to use Icinga Web 2. This is achieved by defining `icingaweb2_authentication`.<br>
 By default the following is set:
 
-```
+```yaml
 icingaweb2_authentication:
   icingaweb2:
     backend: db
@@ -118,10 +118,10 @@ This is also converted to INI and written to `{{ icingaweb2_config_dir }}/authen
 
 ---
 
-Similar to the above snippet group backends can also be defined using `icingaweb2_groups`.  
+Similar to the above snippet group backends can also be defined using `icingaweb2_groups`.<br>
 Default:
 
-```
+```yaml
 icingaweb2_groups:
   icingaweb2:
     backend: db

--- a/doc/role-monitoring_plugins/role-monitoring_plugins.md
+++ b/doc/role-monitoring_plugins/role-monitoring_plugins.md
@@ -1,7 +1,7 @@
 # Ansible Role icinga.icinga.monitoring_plugins
 
 This role manages the installation/removal of many well known check plugins typically used in monitoring systems.<br>
-The list is based on the section *"Plugin Check Commands for Monitoring Plugins"* as seen in the [**Icinga Template Library** (ITL)](https://icinga.com/docs/icinga-2/latest/doc/10-icinga-template-library/#plugin-check-commands-for-monitoring-plugins).<br>
+The list is based on the section *"Plugin Check Commands for Monitoring Plugins"* as seen in the [**Icinga Template Library** (ITL)](https://icinga.com/docs/icinga-2/latest/doc/10-icinga-template-library/#plugin-check-commands-for-monitoring-plugins).
 
 * [List of available check commands](check_command_list.md)
 

--- a/doc/role-monitoring_plugins/role-monitoring_plugins.md
+++ b/doc/role-monitoring_plugins/role-monitoring_plugins.md
@@ -1,7 +1,7 @@
 # Ansible Role icinga.icinga.monitoring_plugins
 
-This role manages the installation/removal of many well known check plugins typically used in monitoring systems.  
-The list is based on the section *"Plugin Check Commands for Monitoring Plugins"* as seen in the [**Icinga Template Library** (ITL)](https://icinga.com/docs/icinga-2/latest/doc/10-icinga-template-library/#plugin-check-commands-for-monitoring-plugins).  
+This role manages the installation/removal of many well known check plugins typically used in monitoring systems.<br>
+The list is based on the section *"Plugin Check Commands for Monitoring Plugins"* as seen in the [**Icinga Template Library** (ITL)](https://icinga.com/docs/icinga-2/latest/doc/10-icinga-template-library/#plugin-check-commands-for-monitoring-plugins).<br>
 
 * [List of available check commands](check_command_list.md)
 
@@ -13,36 +13,36 @@ The list is based on the section *"Plugin Check Commands for Monitoring Plugins"
   Decides whether to activate the epel repository. Default: `false`
   Epel needs to be available to install plugins on RHEL and derivatives.
 
-- `icinga_monitoring_plugins_crb: boolean`  
-  Decides whether to run the equivalent of `dnf --enablerepo crb ...` when installing the necessary packages. Default: `false`  
+- `icinga_monitoring_plugins_crb: boolean`<br>
+  Decides whether to run the equivalent of `dnf --enablerepo crb ...` when installing the necessary packages. Default: `false`<br>
   Enabling CRB/Powertools may be necessary, depending on the plugins wanted and the repositories already enabled.
 
 - `icinga_monitoring_plugins_dependency_repos: list`
-  Decides which repositories are temporarily enabled when installing packages. Defaults to either `crb` or `powertools`.  
-  If the need arises, you can manually overwrite this variable to temporarily enable one or multiple repositories of your choice.  
+  Decides which repositories are temporarily enabled when installing packages. Defaults to either `crb` or `powertools`.<br>
+  If the need arises, you can manually overwrite this variable to temporarily enable one or multiple repositories of your choice.<br>
   You may specify `icinga_monitoring_plugins_dependency_repos: "*"` to temporarily enable every repository present.
 
-- `icinga_monitoring_plugins_remove: boolean`  
-  Decides whether to remove packages that have not been asked for by the user. Default `true`  
+- `icinga_monitoring_plugins_remove: boolean`<br>
+  Decides whether to remove packages that have not been asked for by the user. Default `true`<br>
   The requested check commands are compared against the list of available check commands. Packages not required for installation are removed.
 
-- `icinga_monitoring_plugins_autoremove: boolean`  
+- `icinga_monitoring_plugins_autoremove: boolean`<br>
   Decides whether to automatically remove unneeded dependencies. Default: `false`
 
-- `icinga_monitoring_plugins_check_commands: list`  
-  Decides what check plugins will be installed. Default: `undefined`  
-  An empty list will be accepted.  
+- `icinga_monitoring_plugins_check_commands: list`<br>
+  Decides what check plugins will be installed. Default: `undefined`<br>
+  An empty list will be accepted.<br>
   If undefined, the role will fail. Also see [List of available check commands](check_command_list.md).
 
 ## Check Commands
 
-Check plugins are abreviated only using the base name (`check_apt` becomes `apt`).  
-They are installed using the according packages provided by the distribution.  
-This also means that more than the requested check commands might get installed.  
+Check plugins are abreviated only using the base name (`check_apt` becomes `apt`).<br>
+They are installed using the according packages provided by the distribution.<br>
+This also means that more than the requested check commands might get installed.<br>
 
-To set check plugins to be installed:  
+To set check plugins to be installed:
 
-```
+```yaml
 icinga_monitoring_plugins_check_commands:
     - "ssmtp"
     - "disk"
@@ -52,16 +52,16 @@ icinga_monitoring_plugins_check_commands:
     ...
 ```
 
-To install all available check plugins you can add the word 'all' to the list:  
+To install all available check plugins you can add the word 'all' to the list:
 
-```
+```yaml
 icinga_monitoring_plugins_check_commands:
     - "all"
 ```
 
 ## Example Playbooks
 
-Install check commands  
+Install check commands<br>
 - disk
 - disk_smb
 - dns

--- a/doc/role-repos/role-repos.md
+++ b/doc/role-repos/role-repos.md
@@ -7,14 +7,14 @@ This role configures Icinga 2 related repositories to provide all necessary pack
 
 To enable the EPEL repository.
 
-```
+```yaml
 icinga_repo_epel: true
 icinga_repo_scl: true
 ```
 
-To manage which Icinga Repos to use the following variables: 
+To manage which Icinga Repos to use the following variables:
 
-```
+```yaml
 icinga_repo_stable: true
 icinga_repo_testing: false
 icinga_repo_snapshot: false
@@ -22,7 +22,7 @@ icinga_repo_snapshot: false
 
 To use the Icinga Repository Subscription:
 
-```
+```yaml
 icinga_repo_subscription_username: "Your username"
 icinga_repo_subscription_password: "Your password"
 ```


### PR DESCRIPTION
Fixes up the coloring of code blocks.

Unifies some of the code blocks (there was a file with triple backticks for the first command, but used single backtick format for the rest).

Fixes a syntax error in objects.md where it used quadruple backticks once.

Converts whitespace line breaks to explicit `<br>` tags, as whitespace can be inconsistent and people can randomly litter it on accident - which is exactly the case of some of the touched up files.

Note that the shell commands remain mostly uncolored, but I tagged them anyway, as some editors do support the tags, even if GitHub doesn't.

Is adding a changelog fragment necessary for just a doc change?