### PR TITLE
Fix icinga2_ca_host_port cleanup argument name

### DIFF
--- a/changelogs/fragments/fix-port-var-name.yaml
+++ b/changelogs/fragments/fix-port-var-name.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Icinga2: Correctly rename cleanup argument from icinga2_ca_host_port to ca_host_port"

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -22,7 +22,7 @@
 - name: api feature cleanup arguments list
   set_fact:
     args: "{{ args|default({}) | combine({idx.key: idx.value}) }}"
-  when: idx.key not in ['ca_host', 'icinga2_ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert' ]
+  when: idx.key not in ['ca_host', 'ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert' ]
   loop: "{{ icinga2_dict_features.api |dict2items }}"
   loop_control:
     loop_var: idx


### PR DESCRIPTION
Fixes:
```yaml
fatal: [agent]: FAILED! => 
    msg: 'Call to module failed: Unsupported parameters for (icinga2_apilistener) module:
        ca_host_port. Supported parameters include: accept_commands, accept_config, access_control_allow_origin,
        bind_host, bind_port, cipher_list, environment, file, max_anonymous_clients, name,
        order, state, ticket_salt, tls_handshake_timeout, tls_protocolmin.'
```

Caused by using `ca_host_port`:

```yaml
    icinga2_features:
      - name: api
        ca_host: '123.123.123.123'
        ca_host_port: '443'
```