### PR TITLE
allow multiline managed by ansible

### DIFF
--- a/changelogs/allow_mutiline_maged_string.yml
+++ b/changelogs/allow_mutiline_maged_string.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Allow multiline string as ansible_managed

--- a/roles/icingadb/templates/icingadb.ini.j2
+++ b/roles/icingadb/templates/icingadb.ini.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 database:
 {% if icingadb_database_type is defined %}

--- a/roles/icingadb_redis/templates/icingadb-redis.conf.j2
+++ b/roles/icingadb_redis/templates/icingadb-redis.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 bind {% for host in icingadb_redis_binds %}
 {{ host }}


### PR DESCRIPTION
ansible_managed is allowed to be a multiline string.
the PR lets every line start with a "#". 
