### PR TITLE
Add Director migration and kickstart handlers

### DIFF
--- a/roles/icingaweb2/handlers/main.yml
+++ b/roles/icingaweb2/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Module Director | Apply pending migrations
+  ansible.builtin.command:
+    cmd: icingacli director migration run
+  listen: "run_director_migrations"
+
+- name: Module Director | Run kickstart if required
+  ansible.builtin.command:
+    cmd: icingacli director kickstart run
+  listen: "run_director_kickstart"

--- a/roles/icingaweb2/tasks/modules/director.yml
+++ b/roles/icingaweb2/tasks/modules/director.yml
@@ -25,25 +25,16 @@
   register: _pending
   changed_when: _pending.rc|int == 0
   failed_when: _pending.stdout|length > 0
-  when: icingaweb2_modules['director']['import_schema'] is defined and icingaweb2_modules.director.import_schema and icingaweb2_modules['director']['config'] is defined
-
-- name: Module Director | Apply pending migrations  # noqa: command-instead-of-shell
-  ansible.builtin.shell:
-    cmd: icingacli director migration run
-  when: icingaweb2_modules['director']['import_schema'] is defined and icingaweb2_modules.director.import_schema and icingaweb2_modules['director']['config'] is defined and _pending.rc|int == 0
+  notify: "run_director_migrations"
 
 - name: Module Director | Check if kickstart is required  # noqa: command-instead-of-shell
   ansible.builtin.shell:
     cmd: icingacli director kickstart required
   register: _required
-  changed_when: _required.rc|int == 0
+  changed_when: (_required.rc|int == 0) or (".icinga_host' doesn't exist" in _required.stderr)
   failed_when: _required.rc|int >= 2
   when: icingaweb2_modules['director']['run_kickstart'] is defined and icingaweb2_modules.director.run_kickstart and icingaweb2_modules['director']['kickstart'] is defined
-
-- name: Module Director | Run kickstart if required  # noqa: command-instead-of-shell
-  ansible.builtin.shell:
-    cmd: icingacli director kickstart run
-  when: icingaweb2_modules['director']['run_kickstart'] is defined and icingaweb2_modules.director.run_kickstart and icingaweb2_modules['director']['kickstart'] is defined and _required.rc|int == 0
+  notify: "run_director_kickstart"
 
 - name: Module Director | Ensure installation from source is complete
   when: icingaweb2_modules['director']['source'] == 'git'


### PR DESCRIPTION
This adds handlers to the 'icingaweb2' role to take care of Icinga Director schema migrations and its kickstart. Running multiple roles in order should also run their handlers in order. This way the Icinga 2 API should be up and operational for the Director to use for kickstart.

Fixes #319