### PR TITLE
Refactor task names for clarity and consistency across Icinga2 role

### DIFF
--- a/doc/role-icinga2/features/feature-api.md
+++ b/doc/role-icinga2/features/feature-api.md
@@ -72,7 +72,7 @@ Example if connection and ticket creation should be on the satellite:
 icinga2_features:
   - name: api
     ca_host: icinga-satellite.localdomain
-    ticket_salt: "{{ icinga2_constants.ticket_salt }}"
+    ticket_salt: "{{ icinga2_constants.TicketSalt }}"
   [...]
 icinga2_delegate_host: icinga-satellite.localdomain
 ```
@@ -83,7 +83,7 @@ master host.
 icinga2_features:
   - name: api
     ca_host: icinga-satellite.localdomain
-    ticket_salt: "{{ icinga2_constants.ticket_salt }}"
+    ticket_salt: "{{ icinga2_constants.TicketSalt }}"
   [...]
 icinga2_delegate_host: icinga-master.localdomain
 ```

--- a/plugins/action/icinga2_object.py
+++ b/plugins/action/icinga2_object.py
@@ -18,7 +18,7 @@ class ActionModule(ActionBase):
         args = merge_hash(args.pop('args', {}), args)
         object_type = args.pop('type', None)
 
-        if object_type not in task_vars['icinga2_object_types']:
+        if object_type not in task_vars['__icinga2_object_types']:
             raise AnsibleError('unknown Icinga object type: %s' % object_type)
 
         #
@@ -111,7 +111,7 @@ class ActionModule(ActionBase):
             #
             object_content += Icinga2Parser().parse(
                 obj['args'],
-                list(task_vars['icinga2_combined_constants'].keys()) + task_vars['icinga2_reserved'] + varlist + list(obj['args'].keys()),
+                list(task_vars['icinga2_combined_constants'].keys()) + task_vars['__icinga2_reserved'] + varlist + list(obj['args'].keys()),
                 2
             ) + '}\n'
             copy_action = self._task.copy()

--- a/roles/icinga2/defaults/main.yml
+++ b/roles/icinga2/defaults/main.yml
@@ -1,8 +1,12 @@
 ---
 icinga2_packages: ["icinga2"]
+icinga2_fragments_path: /var/tmp/icinga
+icinga2_config_path: /etc/icinga2
 icinga2_state: started
 icinga2_enabled: true
 icinga2_confd: true
+icinga2_ca_path: /var/lib/icinga2/ca
+icinga2_cert_path: /var/lib/icinga2/certs
 icinga2_plugins:
   - plugins
   - plugins-contrib
@@ -14,6 +18,10 @@ icinga2_features:
   - name: checker
   - name: notification
   - name: mainlog
-icinga2_remote_objects: []
 _icinga2_custom_conf_paths: []
 icinga2_config_host: "{{ ansible_fqdn }}"
+
+icinga2_config_directories:
+  - zones.d/main/commands
+  - zones.d/main/hosts
+  - zones.d/main/services

--- a/roles/icinga2/meta/argument_specs.yml
+++ b/roles/icinga2/meta/argument_specs.yml
@@ -1,0 +1,133 @@
+---
+argument_specs:
+  main:
+    short_description: configure or manage Icinga 2 server and agents
+    description:
+      - Role to install, configure or manage Icinga 2 server and agents.
+    author: |
+      - Lennart Betz <lennart.betz@netways.de>
+      - Thilo Wening <thilo.wening@netways.de>
+      - Thomas Widhalm <thomas.widhalm@netways.de>
+    options:
+      icinga2_packages:
+        description: list of packages to be installed
+        type: list
+        elements: str
+        default: ["icinga2"]
+      icinga2_packages_dependencies:
+        description:
+          - list of packages dependancies to be installed in addition to packages
+          - OS Specific
+        type: list
+        elements: str
+      ansible_selinux: # naming is wrong, should be prefixed with the role name, e.g. icinga2_selinux
+        description:
+          - The Icinga 2 role will automatically detect via Ansible facts if SELinux is enabled on the system.
+          - If this is the case the package icinga2-selinux will be automatically installed.
+          - If the package should be installed, even if SELinux is not enabled or somehow wrongly disabled in Ansible use the following variable.
+        type: dict
+        options:
+          enabled:
+            description: Force installation of package `icinga2-selinux`
+            type: bool
+      icinga2_fragments_path:
+        description: Base installation folder of all icinga content
+        default: /var/tmp/icinga
+      icinga2_config_path:
+        description: folderpath for icinga configuration
+        default: /etc/icinga2
+      icinga2_user:
+        description: local icinga2 user
+      icinga2_group:
+        description: local group for O(icinga2_user)
+      icinga2_constants:
+        description:
+          - Define constants in **constants.conf**.
+          - usefull to define the O(icinga2_constants.NodeName) and O(icinga2_constants.ZoneName)
+          - usefull to define the salt
+        type: dict
+        options:
+          PluginDir:
+            description: the plugin folderpath
+            default: /usr/lib/nagios/plugins
+          ManubulonPluginDir:
+            description: manabulon plugin folderpath
+            default: /usr/lib/nagios/plugins
+          PluginContribDir:
+            description: contrib plugins folderpath
+            default: /usr/lib/nagios/plugins
+          NodeName:
+            description: >
+              - node name
+              - ex: satellite.localdomain
+            default: ansible_fqdn
+          ZoneName:
+            description: >
+              - NodeName
+              - ex: zone-satellite-d1
+            default: NodeName
+          TicketSalt:
+            description: salt
+            default: ''
+      icinga2_features:
+        description:
+          - List of features and their configuration settings to be set
+          - Each feature has its own attributes
+          - Check L(Documentation Icinga 2 Features,https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#features)
+        type: list
+        elements: dict
+        default: >-
+          - name: checker
+          - name: notification
+          - name: mainlog
+      icinga2_config_host:
+        description: hostname of the configuration
+        default: ansible_fqdn
+      icinga2_confd:
+        description:
+          - If the local **conf.d** directory shouldn't be recursively included then the var O(icinga2_confd) should be set to `false`.
+          - >-
+            Otherwise you can use a directory name to set the include to a different folder
+            than **conf.d**. The folder needs to exist below /etc/icinga2. If it should be created by the role use the variable O(icinga2_config_directories) in addition.
+        type: str
+
+      icinga2_config_directories:
+        description:
+          - List of configuration directories to be created
+          - Those directories are only managed when they are part of `zones.d`, `conf.d` or the variable O(icinga2_confd).
+        type: list
+        elements: str
+        default:
+          - zones.d/main/commands
+          - zones.d/main/hosts
+          - zones.d/main/services
+      icinga2_ca_path:
+        description: CA folderpath, used for the API
+        type: str
+        default: /var/lib/icinga2/ca
+      icinga2_cert_path:
+        description: path for certificate to be used by API
+        type: str
+        default: /var/lib/icinga2/certs
+      icinga2_state:
+        description: expected state of the icinga2 service
+        choices: [ reloaded, restarted, started, stopped ]
+        default: started
+      icinga2_enabled:
+        description: expected status of the icinga2 service
+        type: bool
+        default: true
+      icinga2_plugins:
+        description: list of plugins to be included in the icinga2.conf
+        type: list
+        elements: str
+        default:
+          - plugins
+          - plugins-contrib
+          - windows-plugins
+          - nscp
+      icinga2_purge_features:
+        description: >-
+          Decides whether the unmanaged features should be purged or not. Default: true
+        type: bool
+        default: true

--- a/roles/icinga2/meta/argument_specs.yml
+++ b/roles/icinga2/meta/argument_specs.yml
@@ -131,3 +131,16 @@ argument_specs:
           Decides whether the unmanaged features should be purged or not. Default: true
         type: bool
         default: true
+      icinga2_delegate_host:
+        description: >-
+          The role primarily delegates the ticket creation to the Icinga ca host.
+          If the host is not listed with the same name in Ansible, you can set the name of the host in Ansible with this variable.
+          example: `icinga2_delegate_host: icinga-master`
+        type: str
+      # TODO: change logic to make it more separated since not possible to validate as item.split
+      # icinga2_objects:
+      #   description: >-
+      #     List of objects for which configuration file will generated.
+      #     COMPLEX object, can be either dict containing list of dict (host vars), or list of dict...
+      #   type: list
+      #   elements: dict

--- a/roles/icinga2/tasks/configure.yml
+++ b/roles/icinga2/tasks/configure.yml
@@ -1,7 +1,7 @@
 ---
-- name: configure | Populate features (icinga2_dict_features)
+- name: configure | Populate features (__icinga2_dict_features)
   ansible.builtin.set_fact:
-    icinga2_dict_features: "{{ icinga2_dict_features | default({}) | combine({item.name: item}) }}"
+    __icinga2_dict_features: "{{ __icinga2_dict_features | default({}) | combine({item.name: item}) }}"
   with_items: "{{ icinga2_features }}"
 
 - name: configure | Main config file {{ icinga2_config_path + '/icinga2.conf' }}
@@ -12,9 +12,9 @@
     group: "{{ icinga2_group }}"
   notify: check-and-reload-icinga2-service
 
-- name: configure | Merge defaults and user specified constants (set_fact icinga2_combined_constants)
+- name: configure | Merge defaults and user specified constants (set_fact __icinga2_combined_constants)
   ansible.builtin.set_fact:
-    icinga2_combined_constants: "{{ __icinga2_default_constants | combine(icinga2_constants) }}"
+    __icinga2_combined_constants: "{{ __icinga2_default_constants | combine(icinga2_constants) }}"
 
 - name: configure | Set constants in {{ icinga2_config_path + '/constants.conf' }}
   ansible.builtin.template:
@@ -61,7 +61,7 @@
     dest: "{{ item.path }}"
   loop: "{{ result_frag.files }}"
   when:
-    - item.path not in icinga2_local_objects
+    - item.path not in __icinga2_local_objects
     - item.path not in _icinga2_custom_conf_paths
 
 - name: configure | Collect empty config dirs

--- a/roles/icinga2/tasks/configure.yml
+++ b/roles/icinga2/tasks/configure.yml
@@ -1,22 +1,22 @@
 ---
-- name: populate features (icinga2_dict_features)
-  set_fact:
-    icinga2_dict_features: "{{ icinga2_dict_features|default({}) | combine({ item.name: item }) }}"
+- name: configure | Populate features (icinga2_dict_features)
+  ansible.builtin.set_fact:
+    icinga2_dict_features: "{{ icinga2_dict_features | default({}) | combine({item.name: item}) }}"
   with_items: "{{ icinga2_features }}"
 
-- name: main config file {{ icinga2_config_path + '/icinga2.conf' }}
-  template:
+- name: configure | Main config file {{ icinga2_config_path + '/icinga2.conf' }}
+  ansible.builtin.template:
     src: icinga2.conf.j2
     dest: "{{ icinga2_config_path + '/icinga2.conf' }}"
     owner: "{{ icinga2_user }}"
     group: "{{ icinga2_group }}"
   notify: check-and-reload-icinga2-service
 
-- name: merge defaults and user specified constants (set_fact icinga2_combined_constants)
-  set_fact:
-    icinga2_combined_constants: "{{ icinga2_default_constants | combine(icinga2_constants) }}"
+- name: configure | Merge defaults and user specified constants (set_fact icinga2_combined_constants)
+  ansible.builtin.set_fact:
+    icinga2_combined_constants: "{{ __icinga2_default_constants | combine(icinga2_constants) }}"
 
-- name: set constants in {{ icinga2_config_path + '/constants.conf' }}
+- name: configure | Set constants in {{ icinga2_config_path + '/constants.conf' }}
   ansible.builtin.template:
     src: constants.conf.j2
     dest: "{{ icinga2_config_path + '/constants.conf' }}"
@@ -24,18 +24,18 @@
     group: "{{ icinga2_group }}"
   notify: check-and-reload-icinga2-service
 
-- name: features
-  include_tasks: features.yml
+- name: configure | Features
+  ansible.builtin.include_tasks: features.yml
 
-- name: objects
-  include_tasks: objects.yml
+- name: configure | Objects
+  ansible.builtin.include_tasks: objects.yml
 
-- name: ensure monitoring config directories
+- name: configure | Ensure monitoring config directories
   ansible.builtin.file:
     path: "{{ icinga2_config_path }}/{{ item }}"
     state: directory
-    owner: "{{ item.owner | default(icinga2_user) }}"
-    group: "{{ item.group | default(icinga2_group) }}"
+    owner: "{{ icinga2_user }}"
+    group: "{{ icinga2_group }}"
   loop: "{{ icinga2_config_directories }}"
   when:
     - icinga2_config_directories is defined
@@ -48,15 +48,15 @@
     #  - my_own_config.d
     #- item.split('/')[0] in icinga2_local_config or item.split('/')[0] == 'zones.d'
 
-- name: collect config fragments
-  find:
+- name: configure | Collect config fragments
+  ansible.builtin.find:
     path: "{{ icinga2_fragments_path }}"
     recurse: yes
     file_type: file
   register: result_frag
 
-- name: cleanup config files
-  file:
+- name: configure | Cleanup config files
+  ansible.builtin.file:
     state: absent
     dest: "{{ item.path }}"
   loop: "{{ result_frag.files }}"
@@ -64,31 +64,31 @@
     - item.path not in icinga2_local_objects
     - item.path not in _icinga2_custom_conf_paths
 
-- name: collect empty config dirs
-  shell: >-
+- name: configure | Collect empty config dirs
+  ansible.builtin.shell: >-
     find {{ icinga2_fragments_path }} -mindepth 1 -type d -empty
   register: _empty_result
   check_mode: false
   changed_when: _empty_result.stdout_lines |length > 0
 
-- name: remove empty config dirs
-  file:
+- name: configure | Remove empty config dirs
+  ansible.builtin.file:
     state: absent
     path: "{{ item }}"
   loop: "{{ _empty_result.stdout_lines }}"
 
-- name: collect config files
-  find:
+- name: configure | Collect config files
+  ansible.builtin.find:
     path: "{{ icinga2_fragments_path }}"
     recurse: yes
     file_type: directory
     pattern: '*.conf'
   register: result
 
-- name: assemble config files
+- name: configure | Assemble config files
   ansible.builtin.assemble:
     src: "{{ item.path }}"
-    dest: "{{ item.path |regex_replace('^'+icinga2_fragments_path, '/etc/icinga2') }}"
+    dest: "{{ item.path | regex_replace('^' + icinga2_fragments_path, '/etc/icinga2') }}"
     delimiter: ' '
     owner: "{{ icinga2_user }}"
     group: "{{ icinga2_group }}"
@@ -96,18 +96,18 @@
   loop: "{{ result.files }}"
   notify: check-and-reload-icinga2-service
 
-- name: enable features
-  file:
+- name: configure | Enable features
+  ansible.builtin.file:
     state: "{{ 'link' if (item.state is undefined or item.state != 'absent') else 'absent' }}"
-    path: "{{ '/etc/icinga2/features-enabled/' + icinga2_feature_realname[item.name]|default(item.name) + '.conf' }}"
-    src: "{{ '../features-available/' + icinga2_feature_realname[item.name]|default(item.name) + '.conf' if (item.state is undefined or item.state != 'absent') else omit }}"
+    path: "{{ '/etc/icinga2/features-enabled/' + __icinga2_feature_realname[item.name] | default(item.name) + '.conf' }}"
+    src: "{{ '../features-available/' + __icinga2_feature_realname[item.name] | default(item.name) + '.conf' if (item.state is undefined or item.state != 'absent') else omit }}"
   loop: "{{ icinga2_features }}"
   notify: check-and-reload-icinga2-service
 
-- name: remove empty config files
+- name: configure | Remove empty config files
   ansible.builtin.file:
     state: absent
-    path: "{{ item |regex_replace('^'+icinga2_fragments_path, '/etc/icinga2') }}"
+    path: "{{ item | regex_replace('^' + icinga2_fragments_path, '/etc/icinga2') }}"
   when: item.split('/')[icinga2_fragments_path.split('/')|length] == 'conf.d' or item.split('/')[icinga2_fragments_path.split('/')|length] == 'zones.d'
   loop: "{{ _empty_result.stdout_lines }}"
   notify: check-and-reload-icinga2-service

--- a/roles/icinga2/tasks/features.yml
+++ b/roles/icinga2/tasks/features.yml
@@ -1,27 +1,31 @@
 ---
 
-- name: collect all files in {{ icinga2_config_path + '/features-enabled' }}
-  find:
+- name: features | Collect all files in {{ icinga2_config_path + '/features-enabled' }}
+  ansible.builtin.find:
     paths: "{{ icinga2_config_path + '/features-enabled' }}"
     patterns: '*.conf'
     file_type: any
   register: icinga2_collected_features
   when: icinga2_purge_features
 
-- name: collect enabled features
-  set_fact:
-    features_enabled: "{{ features_enabled|default([]) + [ icinga2_feature_realname[item.path| basename| splitext| first]| default(item.path| basename| splitext| first) ] }}"
+- name: features | Collect enabled features
+  ansible.builtin.set_fact:
+    features_enabled: >-
+      {{ features_enabled | default([])
+      + [ __icinga2_feature_realname[item.path | basename| splitext | first]
+        | default(item.path | basename | splitext | first)
+        ] }}
   loop: "{{ icinga2_collected_features.files }}"
   when: icinga2_purge_features
 
-- name: purge features
-  file:
+- name: features | Purge features
+  ansible.builtin.file:
     state: absent
-    path: "{{ '/etc/icinga2/features-enabled/' + icinga2_feature_realname[item]|default(item) + '.conf' }}"
-  loop: "{{ features_enabled | default([]) | difference(icinga2_features| map(attribute='name')|list) }}"
+    path: "{{ '/etc/icinga2/features-enabled/' + __icinga2_feature_realname[item] | default(item) + '.conf' }}"
+  loop: "{{ features_enabled | default([]) | difference(icinga2_features | map(attribute='name') | list) }}"
   notify: check-and-reload-icinga2-service
   when: icinga2_purge_features
 
-- name: configure features
-  include_tasks: "features/{{ item.name }}.yml"
+- name: features | Configure features
+  ansible.builtin.include_tasks: "features/{{ item.name }}.yml"
   loop: "{{ icinga2_features }}"

--- a/roles/icinga2/tasks/features.yml
+++ b/roles/icinga2/tasks/features.yml
@@ -10,8 +10,8 @@
 
 - name: features | Collect enabled features
   ansible.builtin.set_fact:
-    features_enabled: >-
-      {{ features_enabled | default([])
+    __icinga2_features_enabled: >-
+      {{ __icinga2_features_enabled | default([])
       + [ __icinga2_feature_realname[item.path | basename| splitext | first]
         | default(item.path | basename | splitext | first)
         ] }}
@@ -22,7 +22,7 @@
   ansible.builtin.file:
     state: absent
     path: "{{ '/etc/icinga2/features-enabled/' + __icinga2_feature_realname[item] | default(item) + '.conf' }}"
-  loop: "{{ features_enabled | default([]) | difference(icinga2_features | map(attribute='name') | list) }}"
+  loop: "{{ __icinga2_features_enabled | default([]) | difference(icinga2_features | map(attribute='name') | list) }}"
   notify: check-and-reload-icinga2-service
   when: icinga2_purge_features
 

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -1,17 +1,17 @@
 ---
 - name: features | api | Set api feature facts
   ansible.builtin.set_fact:
-    __icinga2_cert_name: "{{ icinga2_dict_features.api.cert_name | default(ansible_fqdn) }}"
-    __icinga2_ca_host: "{{ icinga2_dict_features.api.ca_host | default(omit) }}"
-    __icinga2_ca_host_port: "{{ icinga2_dict_features.api.ca_host_port | default(omit) }}"
-    __icinga2_ca_fingerprint: "{{ icinga2_dict_features.api.ca_fingerprint | default(omit) }}"
-    __icinga2_force_newcert: "{{ icinga2_dict_features.api.force_newcert | default(False) }}"
-    __icinga2_endpoints: "{{ icinga2_dict_features.api.endpoints | default([]) }}"
-    __icinga2_zones: "{{ icinga2_dict_features.api.zones | default([]) }}"
-    __icinga2_ssl_cert: "{{ icinga2_dict_features.api.ssl_cert | default(omit) }}"
-    __icinga2_ssl_cacert: "{{ icinga2_dict_features.api.ssl_cacert | default(omit) }}"
-    __icinga2_ssl_key: "{{ icinga2_dict_features.api.ssl_key | default(omit) }}"
-    __icinga2_ticket_salt: "{{ icinga2_dict_features.api.ticket_salt | default(omit) }}"
+    __icinga2_cert_name: "{{ __icinga2_dict_features.api.cert_name | default(ansible_fqdn) }}"
+    __icinga2_ca_host: "{{ __icinga2_dict_features.api.ca_host | default(omit) }}"
+    __icinga2_ca_host_port: "{{ __icinga2_dict_features.api.ca_host_port | default(omit) }}"
+    __icinga2_ca_fingerprint: "{{ __icinga2_dict_features.api.ca_fingerprint | default(omit) }}"
+    __icinga2_force_newcert: "{{ __icinga2_dict_features.api.force_newcert | default(False) }}"
+    __icinga2_endpoints: "{{ __icinga2_dict_features.api.endpoints | default([]) }}"
+    __icinga2_zones: "{{ __icinga2_dict_features.api.zones | default([]) }}"
+    __icinga2_ssl_cert: "{{ __icinga2_dict_features.api.ssl_cert | default(omit) }}"
+    __icinga2_ssl_cacert: "{{ __icinga2_dict_features.api.ssl_cacert | default(omit) }}"
+    __icinga2_ssl_key: "{{ __icinga2_dict_features.api.ssl_key | default(omit) }}"
+    __icinga2_ticket_salt: "{{ __icinga2_dict_features.api.ticket_salt | default(omit) }}"
 
 - name: features | api | Check CA
   ansible.builtin.assert:
@@ -23,7 +23,7 @@
   when: idx.key not in ['ca_host', 'ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert' ]
   ansible.builtin.set_fact:
     __icinga2_api_args: "{{ __icinga2_api_args | default({}) | combine({idx.key: idx.value}) }}"
-  loop: "{{ icinga2_dict_features.api | dict2items }}"
+  loop: "{{ __icinga2_dict_features.api | dict2items }}"
   loop_control:
     loop_var: idx
 
@@ -37,7 +37,7 @@
 
 - name: features | api | Define local objects
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"
 
 - name: features | api | Endpoint objects
   icinga.icinga.icinga2_object:
@@ -46,12 +46,12 @@
   loop: "{{ __icinga2_endpoints }}"
   loop_control:
     loop_var: idx
-  register: result
+  register: __icinga2_api_endpoints_converted_result
 
 - name: features | api | Append idx to local objects
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [idx.dest] }}"
-  loop: "{{ result.results }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [idx.dest] }}"
+  loop: "{{ __icinga2_api_endpoints_converted_result.results }}"
   loop_control:
     loop_var: idx
 
@@ -62,12 +62,12 @@
   loop: "{{ __icinga2_zones }}"
   loop_control:
     loop_var: idx
-  register: result
+  register: __icinga2_api_zone_converted_result
 
 - name: features | api | Append idx to local objects
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [idx.dest] }}"
-  loop: "{{ result.results }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [idx.dest] }}"
+  loop: "{{ __icinga2_api_zone_converted_result.results }}"
   loop_control:
     loop_var: idx
 
@@ -172,15 +172,6 @@
 #  when: ( __icinga2_ssl_cacert is defined and __icinga2_ssl_cert is defined and __icinga2_ssl_key is defined )
   when: __icinga2_ssl_cacert is defined
   block:
-    - ansible.builtin.set_fact:
-        _tmp_crt:
-          - src: "{{ __icinga2_ssl_cacert }}"
-            dest: "{{ icinga2_cert_path }}/ca.crt"
-          - src: "{{ __icinga2_ssl_key }}"
-            dest: "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.key"
-          - src: "{{ __icinga2_ssl_cert }}"
-            dest: "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.crt"
-
     - name: features | api | Ensure icinga2 certificate directory
       ansible.builtin.file:
         path: "{{ icinga2_cert_path }}"
@@ -197,7 +188,13 @@
         owner: "{{ icinga2_user }}"
         group: "{{ icinga2_group }}"
       notify: check-and-reload-icinga2-service
-      loop: "{{ _tmp_crt }}"
+      loop:
+        - src: "{{ __icinga2_ssl_cacert }}"
+          dest: "{{ icinga2_cert_path }}/ca.crt"
+        - src: "{{ __icinga2_ssl_key }}"
+          dest: "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.key"
+        - src: "{{ __icinga2_ssl_cert }}"
+          dest: "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.crt"
       loop_control:
         loop_var: _crt
 

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -1,189 +1,196 @@
 ---
+- name: features | api | Set api feature facts
+  ansible.builtin.set_fact:
+    __icinga2_cert_name: "{{ icinga2_dict_features.api.cert_name | default(ansible_fqdn) }}"
+    __icinga2_ca_host: "{{ icinga2_dict_features.api.ca_host | default(omit) }}"
+    __icinga2_ca_host_port: "{{ icinga2_dict_features.api.ca_host_port | default(omit) }}"
+    __icinga2_ca_fingerprint: "{{ icinga2_dict_features.api.ca_fingerprint | default(omit) }}"
+    __icinga2_force_newcert: "{{ icinga2_dict_features.api.force_newcert | default(False) }}"
+    __icinga2_endpoints: "{{ icinga2_dict_features.api.endpoints | default([]) }}"
+    __icinga2_zones: "{{ icinga2_dict_features.api.zones | default([]) }}"
+    __icinga2_ssl_cert: "{{ icinga2_dict_features.api.ssl_cert | default(omit) }}"
+    __icinga2_ssl_cacert: "{{ icinga2_dict_features.api.ssl_cacert | default(omit) }}"
+    __icinga2_ssl_key: "{{ icinga2_dict_features.api.ssl_key | default(omit) }}"
+    __icinga2_ticket_salt: "{{ icinga2_dict_features.api.ticket_salt | default(omit) }}"
 
-- name: set api feature facts
-  set_fact:
-    icinga2_cert_name: "{{ icinga2_dict_features.api.cert_name | default(ansible_fqdn) }}"
-    icinga2_ca_host: "{{ icinga2_dict_features.api.ca_host | default(omit) }}"
-    icinga2_ca_host_port: "{{ icinga2_dict_features.api.ca_host_port | default(omit) }}"
-    icinga2_ca_fingerprint: "{{ icinga2_dict_features.api.ca_fingerprint | default(omit) }}"
-    icinga2_force_newcert: "{{ icinga2_dict_features.api.force_newcert | default(False) }}"
-    icinga2_endpoints: "{{ icinga2_dict_features.api.endpoints |default([]) }}"
-    icinga2_zones: "{{ icinga2_dict_features.api.zones | default([]) }}"
-    icinga2_ssl_cert: "{{ icinga2_dict_features.api.ssl_cert | default(omit) }}"
-    icinga2_ssl_cacert: "{{ icinga2_dict_features.api.ssl_cacert | default(omit) }}"
-    icinga2_ssl_key: "{{ icinga2_dict_features.api.ssl_key | default(omit) }}"
-    icinga2_ticket_salt: "{{ icinga2_dict_features.api.ticket_salt | default(omit) }}"
-
-- assert:
-    that: ((icinga2_ssl_cacert is defined and icinga2_ssl_cert is defined and icinga2_ssl_key is defined) or (icinga2_ssl_cacert is undefined and icinga2_ssl_cert is undefined and icinga2_ssl_key is undefined and icinga2_ca_host is defined))
+- name: features | api | Check CA
+  ansible.builtin.assert:
+    that: ((__icinga2_ssl_cacert is defined and __icinga2_ssl_cert is defined and __icinga2_ssl_key is defined) or (__icinga2_ssl_cacert is undefined and __icinga2_ssl_cert is undefined and __icinga2_ssl_key is undefined and __icinga2_ca_host is defined))
     fail_msg: ca_host is mandatory or ssl_cacert/cert/key have to be set at the same time
     success_msg: API Feature is configured correctly
 
-- name: api feature cleanup arguments list
-  set_fact:
-    args: "{{ args|default({}) | combine({idx.key: idx.value}) }}"
+- name: features | api | Cleanup arguments list
   when: idx.key not in ['ca_host', 'ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert' ]
-  loop: "{{ icinga2_dict_features.api |dict2items }}"
+  ansible.builtin.set_fact:
+    __icinga2_api_args: "{{ __icinga2_api_args | default({}) | combine({idx.key: idx.value}) }}"
+  loop: "{{ icinga2_dict_features.api | dict2items }}"
   loop_control:
     loop_var: idx
 
-- name: feature api ApiListener object
-  icinga2_object:
+- name: features | api | ApiListener object
+  icinga.icinga.icinga2_object:
     name: api
     type: ApiListener
-    file: features-available/api.conf
-    args: "{{ args }}"
+    ansible.builtin.file: features-available/api.conf
+    args: "{{ __icinga2_api_args }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | api | Define local objects
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
 
-- name: feature api Endpoint objects
-  icinga2_object:
+- name: features | api | Endpoint objects
+  icinga.icinga.icinga2_object:
     type: Endpoint
     args: "{{ idx }}"
-  loop: "{{ icinga2_endpoints }}"
+  loop: "{{ __icinga2_endpoints }}"
   loop_control:
     loop_var: idx
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [idx.dest] }}"
+- name: features | api | Append idx to local objects
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [idx.dest] }}"
   loop: "{{ result.results }}"
   loop_control:
     loop_var: idx
 
-- name: feature api Zone objects
-  icinga2_object:
+- name: features | api | Zone objects
+  icinga.icinga.icinga2_object:
     type: Zone
     args: "{{ idx }}"
-  loop: "{{ icinga2_zones }}"
+  loop: "{{ __icinga2_zones }}"
   loop_control:
     loop_var: idx
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [idx.dest] }}"
+- name: features | api | Append idx to local objects
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [idx.dest] }}"
   loop: "{{ result.results }}"
   loop_control:
     loop_var: idx
 
-- name: create new CA
+- name: features | api | Create new CA
+  when: __icinga2_ca_host is defined and __icinga2_ca_host == 'none'
   block:
-    - name: check ca key already exists
-      stat:
+    - name: features | api | Check ca key already exists
+      ansible.builtin.stat:
         path: "{{ icinga2_ca_path }}/ca.key"
       register: icinga2_ca_key_path
 
-    - name: check ca cert already exists
-      stat:
+    - name: features | api | Check ca cert already exists
+      ansible.builtin.stat:
         path: "{{ icinga2_ca_path }}/ca.crt"
       register: icinga2_ca_cert_path
 
-    - name: create CA
-      shell: >
+    - name: features | api | Create CA
+      ansible.builtin.shell: >
         icinga2 pki new-ca
-      when: icinga2_ca_cert_path.stat.exists == false and icinga2_ca_key_path.stat.exists == false
-  when: icinga2_ca_host is defined and icinga2_ca_host == 'none'
+      when: not (icinga2_ca_cert_path.stat.exists) and not(icinga2_ca_key_path.stat.exists)
 
-- name: check cert key already exists
-  stat:
-    path: "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.key"
-  register: icinga2_ssl_key_path
+- name: features | api | Check cert key already exists
+  ansible.builtin.stat:
+    path: "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.key"
+  register: __icinga2_ssl_key_path
 
-- name: check certificate already exists
-  stat:
-    path: "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt"
-  register: icinga2_ssl_cert_path
+- name: features | api | Check certificate already exists
+  ansible.builtin.stat:
+    path: "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.crt"
+  register: __icinga2_ssl_cert_path
 
-- name: certificate request
-  when: (icinga2_ssl_cert_path.stat.exists == false or icinga2_ssl_key_path.stat.exists == false or icinga2_force_newcert) and icinga2_ssl_cacert is not defined
+- name: features | api | Certificate request
+  when:
+    - ( not(__icinga2_ssl_cert_path.stat.exists) or not(__icinga2_ssl_key_path.stat.exists) or __icinga2_force_newcert)
+    - __icinga2_ssl_cacert is not defined
   block:
-    - name: create cert path
-      file:
+    - name: features | api | Create cert path
+      ansible.builtin.file:
         path: "{{ icinga2_cert_path }}"
         state: directory
         owner: "{{ icinga2_user }}"
         group: "{{ icinga2_group }}"
         mode: "0750"
 
-    - name: save trusted-master.crt
-      shell: >-
+    - name: features | api | Save trusted-master.crt
+      when: __icinga2_ca_host != 'none'
+      ansible.builtin.shell: >-
         icinga2 pki save-cert
-        --host "{{ icinga2_ca_host }}"
-        --port "{{ icinga2_ca_host_port | default('5665') }}"
+        --host "{{ __icinga2_ca_host }}"
+        --port "{{ __icinga2_ca_host_port | default('5665') }}"
         --trustedcert "{{ icinga2_cert_path }}/trusted-master.crt"
-      when: icinga2_ca_host != 'none'
       register: _trusted_master_cert
 
-    - name: normalize ca fingerprint
-      set_fact:
-        _ca_fingerprint_normalized: "{{ icinga2_ca_fingerprint | upper | replace(':', ' ') }}"
-      when: icinga2_ca_fingerprint is defined
+    - name: features | api | Normalize ca fingerprint
+      when: __icinga2_ca_fingerprint is defined
+      ansible.builtin.set_fact:
+        _ca_fingerprint_normalized: "{{ __icinga2_ca_fingerprint | upper | replace(':', ' ') }}"
 
-    - name: validate ca certificate fingerprint
-      fail:
-        msg: "CA certificate identity not verified. Fingerprint did not match."
+    - name: features | api | Validate ca certificate fingerprint
       when:
-        - icinga2_ca_fingerprint is defined
+        - __icinga2_ca_fingerprint is defined
         - _trusted_master_cert.stdout | regex_search(_ca_fingerprint_normalized, multiline=True) is none
+      ansible.builtin.fail:
+        msg: "CA certificate identity not verified. Fingerprint did not match."
 
-    - name: generate private and public key
-      shell: >-
+    - name: features | api | Generate private and public key
+      ansible.builtin.shell: >-
         icinga2 pki new-cert
-        --cn "{{ icinga2_cert_name }}"
-        --key "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.key"
-        {% if icinga2_ca_host != 'none' %} --cert "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt" {% else %} --csr "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.csr" {%- endif %}
+        --cn "{{ __icinga2_cert_name }}"
+        --key "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.key"
+        {% if __icinga2_ca_host != 'none' %} --cert "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.crt" {% else %} --csr "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.csr"{%- endif %}
 
-    - name: delegate ticket request to master
-      shell: icinga2 pki ticket --cn "{{ icinga2_cert_name }}" {% if icinga2_ticket_salt is defined %} --salt "{{ icinga2_ticket_salt }}"{% endif %}
-      delegate_to: "{{ icinga2_delegate_host | default(icinga2_ca_host) }}"
+    - name: features | api | Delegate ticket request to master
+      when: __icinga2_ca_host != 'none'
+      ansible.builtin.shell: icinga2 pki ticket --cn "{{ __icinga2_cert_name }}" {% if __icinga2_ticket_salt is defined %} --salt "{{ __icinga2_ticket_salt }}"{% endif %}
+      delegate_to: "{{ icinga2_delegate_host | default(__icinga2_ca_host) }}"
       register: icinga2_ticket
-      when: icinga2_ca_host != 'none'
 
-    - name: get certificate
-      shell: >-
-        icinga2 pki {% if icinga2_ca_host != 'none' %} request
+    - name: features | api | Get certificate
+      ansible.builtin.shell: >-
+        icinga2 pki {% if __icinga2_ca_host != 'none' %} request
         --ticket "{{ icinga2_ticket.stdout }}"
-        --host "{{ icinga2_ca_host }}"
-        --port "{{ icinga2_ca_host_port | default('5665') }}"
+        --host "{{ __icinga2_ca_host }}"
+        --port "{{ __icinga2_ca_host_port | default('5665') }}"
         --ca "{{ icinga2_cert_path }}/ca.crt"
-        --key "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.key"
+        --key "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.key"
         --trustedcert "{{ icinga2_cert_path }}/trusted-master.crt"
-        {% else %} sign-csr --csr "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.csr" {%- endif %}
-        --cert "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt"
+        {% else %} sign-csr --csr "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.csr" {%- endif %}
+        --cert "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.crt"
       notify: check-and-reload-icinga2-service
 
-    - name: copy CA root certificate
-      copy:
+    - name: features | api | Copy CA root certificate
+      ansible.builtin.copy:
         src: "{{ icinga2_ca_path }}/ca.crt"
         dest: "{{ icinga2_cert_path }}/ca.crt"
         owner: "{{ icinga2_user }}"
         group: "{{ icinga2_group }}"
         remote_src: yes
-      when: icinga2_ca_host == 'none'
+      when: __icinga2_ca_host == 'none'
 
-- name: Use self generated certificates
+- name: features | api | Use self generated certificates
+#  when: ( __icinga2_ssl_cacert is defined and __icinga2_ssl_cert is defined and __icinga2_ssl_key is defined )
+  when: __icinga2_ssl_cacert is defined
   block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         _tmp_crt:
-          - src: "{{ icinga2_ssl_cacert }}"
+          - src: "{{ __icinga2_ssl_cacert }}"
             dest: "{{ icinga2_cert_path }}/ca.crt"
-          - src: "{{ icinga2_ssl_key }}"
-            dest: "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.key"
-          - src: "{{ icinga2_ssl_cert }}"
-            dest: "{{ icinga2_cert_path }}/{{ icinga2_cert_name }}.crt"
+          - src: "{{ __icinga2_ssl_key }}"
+            dest: "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.key"
+          - src: "{{ __icinga2_ssl_cert }}"
+            dest: "{{ icinga2_cert_path }}/{{ __icinga2_cert_name }}.crt"
 
-    - name: Ensure icinga2 certificate directory
-      file:
+    - name: features | api | Ensure icinga2 certificate directory
+      ansible.builtin.file:
         path: "{{ icinga2_cert_path }}"
         state: directory
         owner: "{{ icinga2_user }}"
         group: "{{ icinga2_group }}"
         mode: "0750"
 
-    - name: Copy self generated certificates to icinga2 certificate directory
-      copy:
+    - name: features | api | Copy self generated certificates to icinga2 certificate directory
+      ansible.builtin.copy:
         remote_src: no
         src: "{{ _crt.src }}"
         dest: "{{ _crt.dest }}"
@@ -193,8 +200,7 @@
       loop: "{{ _tmp_crt }}"
       loop_control:
         loop_var: _crt
-#  when: ( icinga2_ssl_cacert is defined and icinga2_ssl_cert is defined and icinga2_ssl_key is defined )
-  when: icinga2_ssl_cacert is defined
 
-- set_fact:
-    args: None
+- name: features | api | Cleanup
+  ansible.builtin.set_fact:
+    __icinga2_api_args: None

--- a/roles/icinga2/tasks/features/checker.yml
+++ b/roles/icinga2/tasks/features/checker.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature checker CheckerComponent object
-  icinga2_object:
+- name: features | checker | CheckerComponent object
+  icinga.icinga.icinga2_object:
     name: checker
     type: CheckerComponent
-    file: features-available/checker.conf
+    ansible.builtin.file: features-available/checker.conf
     args: "{{ icinga2_dict_features.checker }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | checker | Enhance local objects
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/checker.yml
+++ b/roles/icinga2/tasks/features/checker.yml
@@ -5,9 +5,9 @@
     name: checker
     type: CheckerComponent
     ansible.builtin.file: features-available/checker.conf
-    args: "{{ icinga2_dict_features.checker }}"
+    args: "{{ __icinga2_dict_features.checker }}"
   register: result
 
 - name: features | checker | Enhance local objects
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/command.yml
+++ b/roles/icinga2/tasks/features/command.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature command ExternalCommandListener object
-  icinga2_object:
+- name: features | command | ExternalCommandListener object
+  icinga.icinga.icinga2_object:
     name: command
     type: ExternalCommandListener
-    file: features-available/command.conf
+    ansible.builtin.file: features-available/command.conf
     args: "{{ icinga2_dict_features.command }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | command | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/command.yml
+++ b/roles/icinga2/tasks/features/command.yml
@@ -5,9 +5,9 @@
     name: command
     type: ExternalCommandListener
     ansible.builtin.file: features-available/command.conf
-    args: "{{ icinga2_dict_features.command }}"
+    args: "{{ __icinga2_dict_features.command }}"
   register: result
 
 - name: features | command | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/compatlog.yml
+++ b/roles/icinga2/tasks/features/compatlog.yml
@@ -5,9 +5,9 @@
     name: compatlog
     type: CompatLogger
     ansible.builtin.file: features-available/compatlog.conf
-    args: "{{ icinga2_dict_features.compatlog }}"
+    args: "{{ __icinga2_dict_features.compatlog }}"
   register: result
 
 - name: features | compatlog | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/compatlog.yml
+++ b/roles/icinga2/tasks/features/compatlog.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: Feature compatlog CompatLogger object
+- name: features | compatlog | CompatLogger object
   icinga.icinga.icinga2_object:
     name: compatlog
     type: CompatLogger
-    file: features-available/compatlog.conf
+    ansible.builtin.file: features-available/compatlog.conf
     args: "{{ icinga2_dict_features.compatlog }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | compatlog | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/debuglog.yml
+++ b/roles/icinga2/tasks/features/debuglog.yml
@@ -1,14 +1,15 @@
 ---
 
-- name: feature debuglog FileLogger object
-  icinga2_object:
+- name: features | debuglog | FileLogger object
+  icinga.icinga.icinga2_object:
     name: debug-file
     type: FileLogger
-    file: features-available/debuglog.conf
+    ansible.builtin.file: features-available/debuglog.conf
     path: LogDir + /debug.log
     severity: debug
     args: "{{ icinga2_dict_features.debuglog }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | debuglog | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/debuglog.yml
+++ b/roles/icinga2/tasks/features/debuglog.yml
@@ -7,9 +7,9 @@
     ansible.builtin.file: features-available/debuglog.conf
     path: LogDir + /debug.log
     severity: debug
-    args: "{{ icinga2_dict_features.debuglog }}"
+    args: "{{ __icinga2_dict_features.debuglog }}"
   register: result
 
 - name: features | debuglog | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/elasticsearch.yml
+++ b/roles/icinga2/tasks/features/elasticsearch.yml
@@ -5,9 +5,9 @@
     name: elasticsearch
     type: ElasticsearchWriter
     ansible.builtin.file: features-available/elasticsearch.conf
-    args: "{{ icinga2_dict_features.elasticsearch }}"
+    args: "{{ __icinga2_dict_features.elasticsearch }}"
   register: result
 
 - name: features | elasticsearch | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/elasticsearch.yml
+++ b/roles/icinga2/tasks/features/elasticsearch.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature elasticsearch ElasticsearchWriter object
-  icinga2_object:
+- name: features | elasticsearch | ElasticsearchWriter object
+  icinga.icinga.icinga2_object:
     name: elasticsearch
     type: ElasticsearchWriter
-    file: features-available/elasticsearch.conf
+    ansible.builtin.file: features-available/elasticsearch.conf
     args: "{{ icinga2_dict_features.elasticsearch }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | elasticsearch | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/gelf.yml
+++ b/roles/icinga2/tasks/features/gelf.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature influxdb GelfWriter object
-  icinga2_object:
+- name: features | gelf | GelfWriter object
+  icinga.icinga.icinga2_object:
     name: gelf
     type: GelfWriter
-    file: features-available/gelf.conf
+    ansible.builtin.file: features-available/gelf.conf
     args: "{{ icinga2_dict_features.gelf }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | gelf | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/gelf.yml
+++ b/roles/icinga2/tasks/features/gelf.yml
@@ -5,9 +5,9 @@
     name: gelf
     type: GelfWriter
     ansible.builtin.file: features-available/gelf.conf
-    args: "{{ icinga2_dict_features.gelf }}"
+    args: "{{ __icinga2_dict_features.gelf }}"
   register: result
 
 - name: features | gelf | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/graphite.yml
+++ b/roles/icinga2/tasks/features/graphite.yml
@@ -5,9 +5,9 @@
     name: graphite
     type: GraphiteWriter
     ansible.builtin.file: features-available/graphite.conf
-    args: "{{ icinga2_dict_features.graphite }}"
+    args: "{{ __icinga2_dict_features.graphite }}"
   register: result
 
 - name: features | graphite | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/graphite.yml
+++ b/roles/icinga2/tasks/features/graphite.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature graphite GraphiteWriter object
-  icinga2_object:
+- name: features | graphite | GraphiteWriter object
+  icinga.icinga.icinga2_object:
     name: graphite
     type: GraphiteWriter
-    file: features-available/graphite.conf
+    ansible.builtin.file: features-available/graphite.conf
     args: "{{ icinga2_dict_features.graphite }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | graphite | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/icingadb.yml
+++ b/roles/icinga2/tasks/features/icingadb.yml
@@ -5,9 +5,9 @@
     name: icingadb
     type: IcingaDB
     ansible.builtin.file: features-available/icingadb.conf
-    args: "{{ icinga2_dict_features.icingadb }}"
+    args: "{{ __icinga2_dict_features.icingadb }}"
   register: result
 
 - name: features | icingadb | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/icingadb.yml
+++ b/roles/icinga2/tasks/features/icingadb.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature icingadb IcingaDB object
-  icinga2_object:
+- name: features | icingadb | IcingaDB object
+  icinga.icinga.icinga2_object:
     name: icingadb
     type: IcingaDB
-    file: features-available/icingadb.conf
+    ansible.builtin.file: features-available/icingadb.conf
     args: "{{ icinga2_dict_features.icingadb }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | icingadb | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/idomysql.yml
+++ b/roles/icinga2/tasks/features/idomysql.yml
@@ -1,20 +1,15 @@
 ---
-
-- name: features | idomysql | Set api feature facts
-  ansible.builtin.set_fact:
-    icinga2_import_schema: "{{ icinga2_dict_features.idomysql.import_schema | default(False) }}"
-
 - name: features | idomysql | IdoMysqlConnection object
   icinga.icinga.icinga2_object:
     name: ido-mysql
     type: IdoMysqlConnection
     ansible.builtin.file: features-available/ido-mysql.conf
-    args: "{{ icinga2_dict_features.idomysql }}"
+    args: "{{ __icinga2_dict_features.idomysql }}"
   register: result
 
 - name: features | idomysql | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"
 
 - name: features | idomysql | Install on {{ ansible_os_family }}
   ansible.builtin.include_tasks: "features/idomysql/install_on_{{ ansible_os_family }}.yml"
@@ -22,22 +17,22 @@
 # Hint: For MySQL the client-side --ssl option is deprecated as of MySQL 5.7.11 and is removed in MySQL 8.0. For client programs, use --ssl-mode instead
 # However, MariaDB currently does not offer a --ssl-mode option, MariaDB enables --ssl automatically with other flags
 - name: features | idomysql | MySQL import IDO schema
-  when: icinga2_dict_features.idomysql.import_schema| default(False)
+  when: __icinga2_dict_features.idomysql.import_schema | default(False)
   block:
     - name: features | idomysql | Build mysql command
       ansible.builtin.set_fact:
         __idomysql_cmd: >-
-          mysql {% if icinga2_dict_features.idomysql.host| default('localhost') != 'localhost'  %} -h "{{ icinga2_dict_features.idomysql.host }}" {%- endif %}
-          {% if icinga2_dict_features.idomysql.port is defined %} -P "{{ icinga2_dict_features.idomysql.port }}" {%- endif %}
-          {% if icinga2_dict_features.idomysql.ssl_mode is defined %} --ssl-mode "{{ icinga2_dict_features.idomysql.ssl_mode }}" {%- endif %}
-          {% if icinga2_dict_features.idomysql.ssl_ca is defined %} --ssl-ca "{{ icinga2_dict_features.idomysql.ssl_ca }}" {%- endif %}
-          {% if icinga2_dict_features.idomysql.ssl_cert is defined %} --ssl-cert "{{ icinga2_dict_features.idomysql.ssl_cert }}" {%- endif %}
-          {% if icinga2_dict_features.idomysql.ssl_key is defined %} --ssl-key "{{ icinga2_dict_features.idomysql.ssl_key }}" {%- endif %}
-          {% if icinga2_dict_features.idomysql.ssl_cipher is defined %} --ssl-cipher "{{ icinga2_dict_features.idomysql.ssl_cipher }}" {%- endif %}
-          {% if icinga2_dict_features.idomysql.extra_options is defined %} {{ icinga2_dict_features.idomysql.extra_options }} {%- endif %}
-          -u "{{ icinga2_dict_features.idomysql.user | default('icinga2') }}"
-          -p"{{ icinga2_dict_features.idomysql.password }}"
-          "{{ icinga2_dict_features.idomysql.database | default('icinga2') }}"
+          mysql {% if __icinga2_dict_features.idomysql.host| default('localhost') != 'localhost'  %} -h "{{ __icinga2_dict_features.idomysql.host }}" {%- endif %}
+          {% if __icinga2_dict_features.idomysql.port is defined %} -P "{{ __icinga2_dict_features.idomysql.port }}" {%- endif %}
+          {% if __icinga2_dict_features.idomysql.ssl_mode is defined %} --ssl-mode "{{ __icinga2_dict_features.idomysql.ssl_mode }}" {%- endif %}
+          {% if __icinga2_dict_features.idomysql.ssl_ca is defined %} --ssl-ca "{{ __icinga2_dict_features.idomysql.ssl_ca }}" {%- endif %}
+          {% if __icinga2_dict_features.idomysql.ssl_cert is defined %} --ssl-cert "{{ __icinga2_dict_features.idomysql.ssl_cert }}" {%- endif %}
+          {% if __icinga2_dict_features.idomysql.ssl_key is defined %} --ssl-key "{{ __icinga2_dict_features.idomysql.ssl_key }}" {%- endif %}
+          {% if __icinga2_dict_features.idomysql.ssl_cipher is defined %} --ssl-cipher "{{ __icinga2_dict_features.idomysql.ssl_cipher }}" {%- endif %}
+          {% if __icinga2_dict_features.idomysql.extra_options is defined %} {{ __icinga2_dict_features.idomysql.extra_options }} {%- endif %}
+          -u "{{ __icinga2_dict_features.idomysql.user | default('icinga2') }}"
+          -p"{{ __icinga2_dict_features.idomysql.password }}"
+          "{{ __icinga2_dict_features.idomysql.database | default('icinga2') }}"
 
     - name: features | idomysql | MySQL check for IDO schema
       ansible.builtin.shell: >

--- a/roles/icinga2/tasks/features/idomysql.yml
+++ b/roles/icinga2/tasks/features/idomysql.yml
@@ -1,30 +1,32 @@
 ---
 
-- name: set api feature facts
-  set_fact:
-    icinga2_import_schema: "{{ icinga2_dict_features.idomysql.import_schema| default(False) }}"
+- name: features | idomysql | Set api feature facts
+  ansible.builtin.set_fact:
+    icinga2_import_schema: "{{ icinga2_dict_features.idomysql.import_schema | default(False) }}"
 
-- name: feature idomysql IdoMysqlConnection object
-  icinga2_object:
+- name: features | idomysql | IdoMysqlConnection object
+  icinga.icinga.icinga2_object:
     name: ido-mysql
     type: IdoMysqlConnection
-    file: features-available/ido-mysql.conf
+    ansible.builtin.file: features-available/ido-mysql.conf
     args: "{{ icinga2_dict_features.idomysql }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | idomysql | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
 
-- name: install on {{ ansible_os_family }}
-  include_tasks: "features/idomysql/install_on_{{ ansible_os_family }}.yml"
+- name: features | idomysql | Install on {{ ansible_os_family }}
+  ansible.builtin.include_tasks: "features/idomysql/install_on_{{ ansible_os_family }}.yml"
 
 # Hint: For MySQL the client-side --ssl option is deprecated as of MySQL 5.7.11 and is removed in MySQL 8.0. For client programs, use --ssl-mode instead
 # However, MariaDB currently does not offer a --ssl-mode option, MariaDB enables --ssl automatically with other flags
-- name: MySQL import IDO schema
+- name: features | idomysql | MySQL import IDO schema
+  when: icinga2_dict_features.idomysql.import_schema| default(False)
   block:
-    - name: build mysql command
-      set_fact:
-        mysqlcmd: >-
+    - name: features | idomysql | Build mysql command
+      ansible.builtin.set_fact:
+        __idomysql_cmd: >-
           mysql {% if icinga2_dict_features.idomysql.host| default('localhost') != 'localhost'  %} -h "{{ icinga2_dict_features.idomysql.host }}" {%- endif %}
           {% if icinga2_dict_features.idomysql.port is defined %} -P "{{ icinga2_dict_features.idomysql.port }}" {%- endif %}
           {% if icinga2_dict_features.idomysql.ssl_mode is defined %} --ssl-mode "{{ icinga2_dict_features.idomysql.ssl_mode }}" {%- endif %}
@@ -37,21 +39,17 @@
           -p"{{ icinga2_dict_features.idomysql.password }}"
           "{{ icinga2_dict_features.idomysql.database | default('icinga2') }}"
 
-    - name: MySQL check for IDO schema
-      shell: >
-        {{ mysqlcmd }}
+    - name: features | idomysql | MySQL check for IDO schema
+      ansible.builtin.shell: >
+        {{ __idomysql_cmd }}
         -Ns -e "select version from icinga_dbversion"
       failed_when: false
       changed_when: false
       check_mode: false
-      register: db_schema
+      register: __idomysql_db_schema
 
-    - name: MySQL import IDO schema
-      shell: >
-        {{ mysqlcmd }}
+    - name: features | idomysql | MySQL import IDO schema
+      when: __idomysql_db_schema.rc != 0
+      ansible.builtin.shell: >
+        {{ __idomysql_cmd }}
         < /usr/share/icinga2-ido-mysql/schema/mysql.sql
-      when: db_schema.rc != 0
-  when: icinga2_dict_features.idomysql.import_schema| default(False)
-
-- set_fact:
-    args: None

--- a/roles/icinga2/tasks/features/idomysql/install_on_Debian.yml
+++ b/roles/icinga2/tasks/features/idomysql/install_on_Debian.yml
@@ -1,15 +1,15 @@
 ---
 
-- name: directory dbconfig-common
-  file:
+- name: features | idomysql | install_on_Debian | Directory dbconfig-common
+  ansible.builtin.file:
     state: directory
     path: /etc/dbconfig-common
     owner: root
     group: root
     mode: 0755
 
-- name: DBconfig for IDO MySQL
-  copy:
+- name: features | idomysql | install_on_Debian | DBconfig for IDO MySQL
+  ansible.builtin.copy:
     dest: /etc/dbconfig-common/icinga2-ido-mysql.conf
     content: |
       dbc_install='false'
@@ -19,7 +19,7 @@
     group: root
     mode: 0600
 
-- name: Apt - install package icinga2-ido-mysql
-  apt:
+- name: features | idomysql | install_on_Debian | Apt - install package icinga2-ido-mysql
+  ansible.builtin.apt:
     name: icinga2-ido-mysql
     state: present

--- a/roles/icinga2/tasks/features/idomysql/install_on_RedHat.yml
+++ b/roles/icinga2/tasks/features/idomysql/install_on_RedHat.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Yum - install package icinga2-ido-mysql
-  yum:
+- name: features | idomysql | install_on_RedHat | Yum - install package icinga2-ido-mysql
+  ansible.builtin.yum:
     name: icinga2-ido-mysql
     state: present

--- a/roles/icinga2/tasks/features/idomysql/install_on_Suse.yml
+++ b/roles/icinga2/tasks/features/idomysql/install_on_Suse.yml
@@ -1,4 +1,4 @@
-- name: Zypper - install package icinga2-ido-mysql
+- name: features | idomysql | install_on_Suse | Zypper - install package icinga2-ido-mysql
   community.general.zypper:
     name: icinga2-ido-mysql
     state: present

--- a/roles/icinga2/tasks/features/idopgsql.yml
+++ b/roles/icinga2/tasks/features/idopgsql.yml
@@ -1,27 +1,29 @@
 ---
 
-- name: set api feature facts
-  set_fact:
-    icinga2_import_schema: "{{ icinga2_dict_features.idopgsql.import_schema| default(False) }}"
+- name: features | idopgsql | Set api feature facts
+  ansible.builtin.set_fact:
+    icinga2_import_schema: "{{ icinga2_dict_features.idopgsql.import_schema | default(False) }}"
 
-- name: feature idopgsql IdoPgsqlConnection object
-  icinga2_object:
+- name: features | idopgsql | IdoPgsqlConnection object
+  icinga.icinga.icinga2_object:
     name: ido-pgsql
     type: IdoPgsqlConnection
-    file: features-available/ido-pgsql.conf
+    ansible.builtin.file: features-available/ido-pgsql.conf
     args: "{{ icinga2_dict_features.idopgsql }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | idopgsql | Enhance local objects
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
 
-- name: install on {{ ansible_os_family }}
-  include_tasks: "features/idopgsql/install_on_{{ ansible_os_family }}.yml"
+- name: features | idopgsql | Install on {{ ansible_os_family }}
+  ansible.builtin.include_tasks: "features/idopgsql/install_on_{{ ansible_os_family }}.yml"
 
-- name: PostgreSQL import IDO schema
+- name: features | idopgsql | PostgreSQL import IDO schema
+  when: icinga2_dict_features.idopgsql.import_schema| default(False)
   block:
-    - name: build psql command
-      set_fact:
+    - name: features | idopgsql | Build psql command
+      ansible.builtin.set_fact:
         psqlcmd: >-
           PGPASSWORD="{{ icinga2_dict_features.idopgsql.password }}"
           psql
@@ -34,21 +36,17 @@
           {% if icinga2_dict_features.idopgsql.ssl_key is defined %} sslkey={{ icinga2_dict_features.idopgsql.ssl_key }} {%- endif %}
           {% if icinga2_dict_features.idopgsql.extra_options is defined %} {{ icinga2_dict_features.idopgsql.extra_options }} {%- endif %}"
 
-    - name: PostgreSQL check for IDO schema
-      shell: >
+    - name: features | idopgsql | PostgreSQL check for IDO schema
+      ansible.builtin.shell: >
         {{ psqlcmd }}
         -w -c "select version from icinga_dbversion"
       failed_when: false
       changed_when: false
       check_mode: false
-      register: db_schema
+      register: __idopgsql_db_schema
 
-    - name: PostgreSQL import IDO schema
-      shell: >
+    - name: features | idopgsql | PostgreSQL import IDO schema
+      when: __idopgsql_db_schema.rc != 0
+      ansible.builtin.shell: >
         {{ psqlcmd }}
         -w -f /usr/share/icinga2-ido-pgsql/schema/pgsql.sql
-      when: db_schema.rc != 0
-  when: icinga2_dict_features.idopgsql.import_schema| default(False)
-
-- set_fact:
-    args: None

--- a/roles/icinga2/tasks/features/idopgsql.yml
+++ b/roles/icinga2/tasks/features/idopgsql.yml
@@ -1,44 +1,40 @@
 ---
 
-- name: features | idopgsql | Set api feature facts
-  ansible.builtin.set_fact:
-    icinga2_import_schema: "{{ icinga2_dict_features.idopgsql.import_schema | default(False) }}"
-
 - name: features | idopgsql | IdoPgsqlConnection object
   icinga.icinga.icinga2_object:
     name: ido-pgsql
     type: IdoPgsqlConnection
     ansible.builtin.file: features-available/ido-pgsql.conf
-    args: "{{ icinga2_dict_features.idopgsql }}"
+    args: "{{ __icinga2_dict_features.idopgsql }}"
   register: result
 
 - name: features | idopgsql | Enhance local objects
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"
 
 - name: features | idopgsql | Install on {{ ansible_os_family }}
   ansible.builtin.include_tasks: "features/idopgsql/install_on_{{ ansible_os_family }}.yml"
 
 - name: features | idopgsql | PostgreSQL import IDO schema
-  when: icinga2_dict_features.idopgsql.import_schema| default(False)
+  when: __icinga2_dict_features.idopgsql.import_schema| default(False)
   block:
     - name: features | idopgsql | Build psql command
       ansible.builtin.set_fact:
-        psqlcmd: >-
-          PGPASSWORD="{{ icinga2_dict_features.idopgsql.password }}"
+        __icinga2_idopgsql_sqlcmd: >-
+          PGPASSWORD="{{ __icinga2_dict_features.idopgsql.password }}"
           psql
-          "host={{ icinga2_dict_features.idopgsql.host| default('localhost') }}
-          port={{ icinga2_dict_features.idopgsql.port| default('5432') }}
-          user={{ icinga2_dict_features.idopgsql.user| default('icinga2') }}
-          dbname={{ icinga2_dict_features.idopgsql.database |default('icinga2') }}
-          {% if icinga2_dict_features.idopgsql.ssl_mode is defined %} sslmode={{ icinga2_dict_features.idopgsql.ssl_mode | default('require') }} {%- endif %}
-          {% if icinga2_dict_features.idopgsql.ssl_cert is defined %} sslcert={{ icinga2_dict_features.idopgsql.ssl_cert  }} {%- endif %}
-          {% if icinga2_dict_features.idopgsql.ssl_key is defined %} sslkey={{ icinga2_dict_features.idopgsql.ssl_key }} {%- endif %}
-          {% if icinga2_dict_features.idopgsql.extra_options is defined %} {{ icinga2_dict_features.idopgsql.extra_options }} {%- endif %}"
+          "host={{ __icinga2_dict_features.idopgsql.host| default('localhost') }}
+          port={{ __icinga2_dict_features.idopgsql.port| default('5432') }}
+          user={{ __icinga2_dict_features.idopgsql.user| default('icinga2') }}
+          dbname={{ __icinga2_dict_features.idopgsql.database |default('icinga2') }}
+          {% if __icinga2_dict_features.idopgsql.ssl_mode is defined %} sslmode={{ __icinga2_dict_features.idopgsql.ssl_mode | default('require') }} {%- endif %}
+          {% if __icinga2_dict_features.idopgsql.ssl_cert is defined %} sslcert={{ __icinga2_dict_features.idopgsql.ssl_cert  }} {%- endif %}
+          {% if __icinga2_dict_features.idopgsql.ssl_key is defined %} sslkey={{ __icinga2_dict_features.idopgsql.ssl_key }} {%- endif %}
+          {% if __icinga2_dict_features.idopgsql.extra_options is defined %} {{ __icinga2_dict_features.idopgsql.extra_options }} {%- endif %}"
 
     - name: features | idopgsql | PostgreSQL check for IDO schema
       ansible.builtin.shell: >
-        {{ psqlcmd }}
+        {{ __icinga2_idopgsql_sqlcmd }}
         -w -c "select version from icinga_dbversion"
       failed_when: false
       changed_when: false
@@ -48,5 +44,5 @@
     - name: features | idopgsql | PostgreSQL import IDO schema
       when: __idopgsql_db_schema.rc != 0
       ansible.builtin.shell: >
-        {{ psqlcmd }}
+        {{ __icinga2_idopgsql_sqlcmd }}
         -w -f /usr/share/icinga2-ido-pgsql/schema/pgsql.sql

--- a/roles/icinga2/tasks/features/idopgsql/install_on_Debian.yml
+++ b/roles/icinga2/tasks/features/idopgsql/install_on_Debian.yml
@@ -1,15 +1,14 @@
 ---
-
-- name: directory dbconfig-common
-  file:
+- name: features | idopgsql | install_on_Debian | Directory dbconfig-common
+  ansible.builtin.file:
     state: directory
     path: /etc/dbconfig-common
     owner: root
     group: root
     mode: 0755
 
-- name: DBconfig for IDO PostgreSQL
-  copy:
+- name: features | idopgsql | install_on_Debian | DBconfig for IDO PostgreSQL
+  ansible.builtin.copy:
     dest: /etc/dbconfig-common/icinga2-ido-pgsql.conf
     content: |
       dbc_install='false'
@@ -19,7 +18,7 @@
     group: root
     mode: 0600
 
-- name: Apt - install package icinga2-ido-pgsql
-  apt:
+- name: features | idopgsql | install_on_Debian | Apt - install package icinga2-ido-pgsql
+  ansible.builtin.apt:
     name: icinga2-ido-pgsql
     state: present

--- a/roles/icinga2/tasks/features/idopgsql/install_on_RedHat.yml
+++ b/roles/icinga2/tasks/features/idopgsql/install_on_RedHat.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Yum - install package icinga2-ido-pgsql
-  yum:
+- name: features | idopgsql | install_on_RedHat | Yum - install package icinga2-ido-pgsql
+  ansible.builtin.yum:
     name: icinga2-ido-pgsql
     state: present

--- a/roles/icinga2/tasks/features/idopgsql/install_on_Suse.yml
+++ b/roles/icinga2/tasks/features/idopgsql/install_on_Suse.yml
@@ -1,4 +1,4 @@
-- name: Zypper - install package icinga2-ido-pgsql
+- name: features | idopgsql | install_on_Suse | Zypper - install package icinga2-ido-pgsql
   community.general.zypper:
     name: icinga2-ido-pgsql
     state: present

--- a/roles/icinga2/tasks/features/influxdb.yml
+++ b/roles/icinga2/tasks/features/influxdb.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature influxdb InfluxdbWriter object
-  icinga2_object:
+- name: features | influxdb | InfluxdbWriter object
+  icinga.icinga.icinga2_object:
     name: influxdb
     type: InfluxdbWriter
-    file: features-available/influxdb.conf
+    ansible.builtin.file: features-available/influxdb.conf
     args: "{{ icinga2_dict_features.influxdb }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | influxdb | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/influxdb.yml
+++ b/roles/icinga2/tasks/features/influxdb.yml
@@ -5,9 +5,9 @@
     name: influxdb
     type: InfluxdbWriter
     ansible.builtin.file: features-available/influxdb.conf
-    args: "{{ icinga2_dict_features.influxdb }}"
+    args: "{{ __icinga2_dict_features.influxdb }}"
   register: result
 
 - name: features | influxdb | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/influxdb2.yml
+++ b/roles/icinga2/tasks/features/influxdb2.yml
@@ -5,9 +5,9 @@
     name: influxdb2
     type: Influxdb2Writer
     ansible.builtin.file: features-available/influxdb2.conf
-    args: "{{ icinga2_dict_features.influxdb2 }}"
+    args: "{{ __icinga2_dict_features.influxdb2 }}"
   register: result
 
 - name: features | influxdb2 | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/influxdb2.yml
+++ b/roles/icinga2/tasks/features/influxdb2.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature influxdb2 Influxdb2Writer object
-  icinga2_object:
+- name: features | influxdb2 | Influxdb2Writer object
+  icinga.icinga.icinga2_object:
     name: influxdb2
     type: Influxdb2Writer
-    file: features-available/influxdb2.conf
+    ansible.builtin.file: features-available/influxdb2.conf
     args: "{{ icinga2_dict_features.influxdb2 }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | influxdb2 | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/livestatus.yml
+++ b/roles/icinga2/tasks/features/livestatus.yml
@@ -5,9 +5,9 @@
     name: livestatus
     type: LivestatusListener
     ansible.builtin.file: features-available/livestatus.conf
-    args: "{{ icinga2_dict_features.livestatus }}"
+    args: "{{ __icinga2_dict_features.livestatus }}"
   register: result
 
 - name: features | livestatus | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/livestatus.yml
+++ b/roles/icinga2/tasks/features/livestatus.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature livestatus LivestatusListener object
-  icinga2_object:
+- name: features | livestatus | LivestatusListener object
+  icinga.icinga.icinga2_object:
     name: livestatus
     type: LivestatusListener
-    file: features-available/livestatus.conf
+    ansible.builtin.file: features-available/livestatus.conf
     args: "{{ icinga2_dict_features.livestatus }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | livestatus | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/mainlog.yml
+++ b/roles/icinga2/tasks/features/mainlog.yml
@@ -5,9 +5,9 @@
     name: main-log
     type: FileLogger
     ansible.builtin.file: features-available/mainlog.conf
-    args: "{{ icinga2_dict_features.mainlog }}"
+    args: "{{ __icinga2_dict_features.mainlog }}"
   register: result
 
 - name: features | mainlog | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/mainlog.yml
+++ b/roles/icinga2/tasks/features/mainlog.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature mainlog FileLogger object
-  icinga2_object:
+- name: features | mainlog | FileLogger object
+  icinga.icinga.icinga2_object:
     name: main-log
     type: FileLogger
-    file: features-available/mainlog.conf
+    ansible.builtin.file: features-available/mainlog.conf
     args: "{{ icinga2_dict_features.mainlog }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | mainlog | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/notification.yml
+++ b/roles/icinga2/tasks/features/notification.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature notification NotificationComponent object
-  icinga2_object:
+- name: features | notification | NotificationComponent object
+  icinga.icinga.icinga2_object:
     name: notification
     type: NotificationComponent
-    file: features-available/notification.conf
+    ansible.builtin.file: features-available/notification.conf
     args: "{{ icinga2_dict_features.notification }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | notification | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/notification.yml
+++ b/roles/icinga2/tasks/features/notification.yml
@@ -5,9 +5,9 @@
     name: notification
     type: NotificationComponent
     ansible.builtin.file: features-available/notification.conf
-    args: "{{ icinga2_dict_features.notification }}"
+    args: "{{ __icinga2_dict_features.notification }}"
   register: result
 
 - name: features | notification | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/opentsdb.yml
+++ b/roles/icinga2/tasks/features/opentsdb.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature influxdb OpenTsdbWriter object
-  icinga2_object:
+- name: features | opentsdb | OpenTsdbWriter object
+  icinga.icinga.icinga2_object:
     name: opentsdb
     type: OpenTsdbWriter
-    file: features-available/opentsdb.conf
+    ansible.builtin.file: features-available/opentsdb.conf
     args: "{{ icinga2_dict_features.opentsdb }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | opentsdb | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/opentsdb.yml
+++ b/roles/icinga2/tasks/features/opentsdb.yml
@@ -5,9 +5,9 @@
     name: opentsdb
     type: OpenTsdbWriter
     ansible.builtin.file: features-available/opentsdb.conf
-    args: "{{ icinga2_dict_features.opentsdb }}"
+    args: "{{ __icinga2_dict_features.opentsdb }}"
   register: result
 
 - name: features | opentsdb | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/perfdata.yml
+++ b/roles/icinga2/tasks/features/perfdata.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature perfdata PerfdataWriter object
-  icinga2_object:
+- name: features | perfdata | PerfdataWriter object
+  icinga.icinga.icinga2_object:
     name: perfdata
     type: PerfdataWriter
-    file: features-available/perfdata.conf
+    ansible.builtin.file: features-available/perfdata.conf
     args: "{{ icinga2_dict_features.perfdata }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | perfdata | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/perfdata.yml
+++ b/roles/icinga2/tasks/features/perfdata.yml
@@ -5,9 +5,9 @@
     name: perfdata
     type: PerfdataWriter
     ansible.builtin.file: features-available/perfdata.conf
-    args: "{{ icinga2_dict_features.perfdata }}"
+    args: "{{ __icinga2_dict_features.perfdata }}"
   register: result
 
 - name: features | perfdata | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/syslog.yml
+++ b/roles/icinga2/tasks/features/syslog.yml
@@ -5,9 +5,9 @@
     name: syslog
     type: SyslogLogger
     ansible.builtin.file: features-available/syslog.conf
-    args: "{{ icinga2_dict_features.syslog }}"
+    args: "{{ __icinga2_dict_features.syslog }}"
   register: result
 
 - name: features | syslog | Enhance local object
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/features/syslog.yml
+++ b/roles/icinga2/tasks/features/syslog.yml
@@ -1,12 +1,13 @@
 ---
 
-- name: feature syslog SyslogLogger object
-  icinga2_object:
+- name: features | syslog | SyslogLogger object
+  icinga.icinga.icinga2_object:
     name: syslog
     type: SyslogLogger
-    file: features-available/syslog.conf
+    ansible.builtin.file: features-available/syslog.conf
     args: "{{ icinga2_dict_features.syslog }}"
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [result.dest] }}"
+- name: features | syslog | Enhance local object
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [result.dest] }}"

--- a/roles/icinga2/tasks/install.yml
+++ b/roles/icinga2/tasks/install.yml
@@ -1,14 +1,14 @@
 ---
-- name: Check supported operatingsystems
+- name: install | Check supported operatingsystems
   block:
-    - name: Install on {{ ansible_os_family }}
+    - name: install | Install on {{ ansible_os_family }}
       ansible.builtin.include_tasks: "install_on_{{ ansible_os_family }}.yml"
   rescue:
-    - name: "OS family not supported!"
+    - name: "install | OS family not supported!"
       ansible.builtin.fail:
         msg: "The OS {{ ansible_os_family }} is not supported!"
 
-- name: Prepare fragments path
+- name: install | Prepare fragments path
   ansible.builtin.file:
     state: directory
     path: "{{ icinga2_fragments_path }}"

--- a/roles/icinga2/tasks/install_on_Debian.yml
+++ b/roles/icinga2/tasks/install_on_Debian.yml
@@ -1,5 +1,5 @@
 ---
-- name: Apt - install package icinga2
+- name: install_on_Debian | Apt - install package icinga2
   ansible.builtin.apt:
     pkg: "{{ icinga2_packages + icinga2_packages_dependencies }}"
     state: present

--- a/roles/icinga2/tasks/install_on_RedHat.yml
+++ b/roles/icinga2/tasks/install_on_RedHat.yml
@@ -1,4 +1,4 @@
-- name: Yum - install package icinga2
+- name: install_on_RedHat | Yum - install package icinga2
   ansible.builtin.yum:
     name: "{{ icinga2_packages + icinga2_packages_dependencies }}"
     state: present

--- a/roles/icinga2/tasks/install_on_Suse.yml
+++ b/roles/icinga2/tasks/install_on_Suse.yml
@@ -1,10 +1,10 @@
 ---
-- name: Zypper - install package icinga2
+- name: install_on_Suse | Zypper - install package icinga2
   community.general.zypper:
     name: "{{ icinga2_packages + icinga2_packages_dependencies }}"
     state: present
 
-- name: Zypper - install package icinga2-selinux
+- name: install_on_Suse | Zypper - install package icinga2-selinux
   community.general.zypper:
     name: icinga2-selinux
     state: present

--- a/roles/icinga2/tasks/main.yml
+++ b/roles/icinga2/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- gather_facts:
+- name: Gather facts
+  ansible.builtin.gather_facts:
 
 - name: Include OS specific vars
-  include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
@@ -14,11 +15,11 @@
       paths:
         - "{{ role_path }}/vars"
 
-- name: install
-  include_tasks: install.yml
+- name: Install
+  ansible.builtin.include_tasks: install.yml
 
-- name: configure
-  include_tasks: configure.yml
+- name: Configure
+  ansible.builtin.include_tasks: configure.yml
 
-- name: manage service
-  include_tasks: service.yml
+- name: Manage service
+  ansible.builtin.include_tasks: service.yml

--- a/roles/icinga2/tasks/objects.yml
+++ b/roles/icinga2/tasks/objects.yml
@@ -1,22 +1,22 @@
 ---
 - name: objects | Collect all config objects for myself (from all inventory hosts)
-  ansible.builtin.set_fact:
-    tmp_objects: "{{ tmp_objects | default([]) + lookup('list', hostvars[item]['icinga2_objects'][icinga2_config_host]) }}"
-  with_items: "{{ groups['all'] }}"
   when: hostvars[item]['icinga2_objects'][icinga2_config_host] is defined
+  ansible.builtin.set_fact:
+    __icinga2_tmp_objects: "{{ __icinga2_tmp_objects | default([]) + lookup('list', hostvars[item]['icinga2_objects'][icinga2_config_host]) }}"
+  with_items: "{{ groups['all'] }}"
 
 - name: objects | Collect all config objects for myself (from myself if list)
-  ansible.builtin.set_fact:
-    tmp_objects: "{{ tmp_objects | default([]) + lookup('list', hostvars[inventory_hostname]['icinga2_objects']) }}"
   when:
     - hostvars[inventory_hostname]['icinga2_objects'] is defined
     - hostvars[inventory_hostname]['icinga2_objects'] is iterable
     - hostvars[inventory_hostname]['icinga2_objects'] is not string
     - hostvars[inventory_hostname]['icinga2_objects'] is not mapping
+  ansible.builtin.set_fact:
+    __icinga2_tmp_objects: "{{ __icinga2_tmp_objects | default([]) + lookup('list', hostvars[inventory_hostname]['icinga2_objects']) }}"
 
 - name: objects | Collect all config objects in play vars
   ansible.builtin.set_fact:
-    tmp_objects: "{{ tmp_objects | default([]) + lookup('list', icinga2_objects) }}"
+    __icinga2_tmp_objects: "{{ __icinga2_tmp_objects | default([]) + lookup('list', icinga2_objects) }}"
   when:
     - icinga2_objects is defined
     - icinga2_objects is iterable
@@ -24,17 +24,17 @@
     - icinga2_objects is not mapping
 
 - name: objects | Convert collected objects to API Object
+  when: __icinga2_tmp_objects is defined
   icinga.icinga.icinga2_object:
     args: "{{ item }}"
-  with_items: "{{ tmp_objects }}"
-  when: tmp_objects is defined
-  register: result
+  with_items: "{{ __icinga2_tmp_objects }}"
+  register: __icinga2_objects_converted
 
 - name: objects | Prepare configs as API objects
+  when: __icinga2_objects_converted.results is defined
   ansible.builtin.set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [item.dest] }}"
-  with_items: "{{ result.results }}"
-  when: result.results is defined
+    __icinga2_local_objects: "{{ __icinga2_local_objects | default([]) + [item.dest] }}"
+  with_items: "{{ __icinga2_objects_converted.results }}"
 
 - name: objects | Prepare custom config
   when: icinga2_custom_config is defined and icinga2_custom_config|length > 0

--- a/roles/icinga2/tasks/objects.yml
+++ b/roles/icinga2/tasks/objects.yml
@@ -1,12 +1,12 @@
 ---
-- name: collect all config objects for myself (from all inventory hosts)
-  set_fact:
-    tmp_objects: "{{ tmp_objects| default([]) + lookup('list', hostvars[item]['icinga2_objects'][icinga2_config_host]) }}"
+- name: objects | Collect all config objects for myself (from all inventory hosts)
+  ansible.builtin.set_fact:
+    tmp_objects: "{{ tmp_objects | default([]) + lookup('list', hostvars[item]['icinga2_objects'][icinga2_config_host]) }}"
   with_items: "{{ groups['all'] }}"
   when: hostvars[item]['icinga2_objects'][icinga2_config_host] is defined
 
-- name: collect all config objects for myself (from myself if list)
-  set_fact:
+- name: objects | Collect all config objects for myself (from myself if list)
+  ansible.builtin.set_fact:
     tmp_objects: "{{ tmp_objects | default([]) + lookup('list', hostvars[inventory_hostname]['icinga2_objects']) }}"
   when:
     - hostvars[inventory_hostname]['icinga2_objects'] is defined
@@ -14,36 +14,43 @@
     - hostvars[inventory_hostname]['icinga2_objects'] is not string
     - hostvars[inventory_hostname]['icinga2_objects'] is not mapping
 
-- name: collect all config objects in play vars
-  set_fact:
-    tmp_objects: "{{ tmp_objects| default([]) + lookup('list', icinga2_objects) }}"
+- name: objects | Collect all config objects in play vars
+  ansible.builtin.set_fact:
+    tmp_objects: "{{ tmp_objects | default([]) + lookup('list', icinga2_objects) }}"
   when:
     - icinga2_objects is defined
     - icinga2_objects is iterable
     - icinga2_objects is not string
     - icinga2_objects is not mapping
 
-- icinga2_object:
+- name: objects | Convert collected objects to API Object
+  icinga.icinga.icinga2_object:
     args: "{{ item }}"
   with_items: "{{ tmp_objects }}"
   when: tmp_objects is defined
   register: result
 
-- set_fact:
-    icinga2_local_objects: "{{ icinga2_local_objects|default([]) + [item.dest] }}"
+- name: objects | Prepare configs as API objects
+  ansible.builtin.set_fact:
+    icinga2_local_objects: "{{ icinga2_local_objects | default([]) + [item.dest] }}"
   with_items: "{{ result.results }}"
   when: result.results is defined
 
-- name: prepare custom config
+- name: objects | Prepare custom config
   when: icinga2_custom_config is defined and icinga2_custom_config|length > 0
   block:
-    - name: construct _icinga2_custom_conf_paths
-      set_fact:
-        _icinga2_custom_conf_paths: "{{ _icinga2_custom_conf_paths + [ icinga2_fragments_path + '/' + item.path + '/' + item.order|default('20')|string + '_' + (item.name | replace('/', '_'))] }}"
+    - name: objects | Construct _icinga2_custom_conf_paths
+      ansible.builtin.set_fact:
+        _icinga2_custom_conf_paths: >-
+          {{ _icinga2_custom_conf_paths
+          + [ icinga2_fragments_path + '/' + item.path + '/' + item.order|default('20') | string
+            + '_' + (item.name | replace('/', '_'))
+            ]
+          }}
       loop: "{{ icinga2_custom_config }}"
 
-    - name: prepare custom config paths
-      file:
+    - name: objects | Prepare custom config paths
+      ansible.builtin.file:
         state: directory
         owner: root
         group: root
@@ -51,11 +58,11 @@
         path: "{{ icinga2_fragments_path }}/{{ item.path }}/"
       loop: "{{ icinga2_custom_config }}"
 
-    - name: add custom config to assemble
+    - name: objects | Add custom config to assemble
       ansible.builtin.copy:
         owner: root
         group: root
         mode: 0644
         src: "files/{{ item.name }}"
-        dest: "{{ icinga2_fragments_path }}/{{ item.path }}/{{ item.order|default('20')|string }}_{{ item.name | replace('/', '_') }}"
+        dest: "{{ icinga2_fragments_path }}/{{ item.path }}/{{ item.order | default('20') | string }}_{{ item.name | replace('/', '_') }}"
       loop: "{{ icinga2_custom_config }}"

--- a/roles/icinga2/tasks/service.yml
+++ b/roles/icinga2/tasks/service.yml
@@ -1,6 +1,6 @@
 ---
-- name: "{{ icinga2_state }} service icinga2"
-  service:
+- name: "service | {{ icinga2_state }} service icinga2" # noqa name[template]
+  ansible.builtin.service:
     name: icinga2
     state: "{{ icinga2_state }}"
     enabled: "{{ icinga2_enabled }}"

--- a/roles/icinga2/templates/constants.conf.j2
+++ b/roles/icinga2/templates/constants.conf.j2
@@ -3,4 +3,4 @@
  * the other configuration files.
  */
 
-{{ lookup('icinga.icinga.icinga2_parser', icinga2_combined_constants| icinga.icinga.prefix('const '), constants=icinga2_combined_constants, reserved=icinga2_reserved, indent=0) }}
+{{ lookup('icinga.icinga.icinga2_parser', icinga2_combined_constants| icinga.icinga.prefix('const '), constants=icinga2_combined_constants, reserved=__icinga2_reserved, indent=0) }}

--- a/roles/icinga2/templates/constants.conf.j2
+++ b/roles/icinga2/templates/constants.conf.j2
@@ -3,4 +3,4 @@
  * the other configuration files.
  */
 
-{{ lookup('icinga.icinga.icinga2_parser', icinga2_combined_constants| icinga.icinga.prefix('const '), constants=icinga2_combined_constants, reserved=__icinga2_reserved, indent=0) }}
+{{ lookup('icinga.icinga.icinga2_parser', __icinga2_combined_constants| icinga.icinga.prefix('const '), constants=__icinga2_combined_constants, reserved=__icinga2_reserved, indent=0) }}

--- a/roles/icinga2/vars/Debian.yml
+++ b/roles/icinga2/vars/Debian.yml
@@ -2,15 +2,3 @@
 icinga2_packages_dependencies: []
 icinga2_user: nagios
 icinga2_group: nagios
-icinga2_config_path: /etc/icinga2
-icinga2_log_path: /var/log/icinga2
-icinga2_ca_path: /var/lib/icinga2/ca
-icinga2_cert_path: /var/lib/icinga2/certs
-icinga2_fragments_path: /var/tmp/icinga
-icinga2_default_constants:
-  PluginDir: /usr/lib/nagios/plugins
-  ManubulonPluginDir: /usr/lib/nagios/plugins
-  PluginContribDir: /usr/lib/nagios/plugins
-  NodeName: "{{ ansible_fqdn }}"
-  ZoneName: NodeName
-  TicketSalt: ''

--- a/roles/icinga2/vars/RedHat.yml
+++ b/roles/icinga2/vars/RedHat.yml
@@ -2,15 +2,3 @@
 icinga2_packages_dependencies: []
 icinga2_user: icinga
 icinga2_group: icinga
-icinga2_config_path: /etc/icinga2
-icinga2_log_path: /var/log/icinga2
-icinga2_ca_path: /var/lib/icinga2/ca
-icinga2_cert_path: /var/lib/icinga2/certs
-icinga2_fragments_path: /var/tmp/icinga
-icinga2_default_constants:
-  PluginDir: /usr/lib64/nagios/plugins
-  ManubulonPluginDir: /usr/lib64/nagios/plugins
-  PluginContribDir: /usr/lib64/nagios/plugins
-  NodeName: "{{ ansible_fqdn }}"
-  ZoneName: NodeName
-  TicketSalt: ''

--- a/roles/icinga2/vars/Suse-12.yml
+++ b/roles/icinga2/vars/Suse-12.yml
@@ -2,15 +2,3 @@
 icinga2_packages_dependencies: ["libboost_regex1_54_0"]
 icinga2_user: icinga
 icinga2_group: icinga
-icinga2_config_path: /etc/icinga2
-icinga2_log_path: /var/log/icinga2
-icinga2_ca_path: /var/lib/icinga2/ca
-icinga2_cert_path: /var/lib/icinga2/certs
-icinga2_fragments_path: /var/tmp/icinga
-icinga2_default_constants:
-  PluginDir: /usr/lib/nagios/plugins/
-  ManubulonPluginDir: /usr/lib/nagios/plugins/
-  PluginContribDir: /usr/lib/nagios/plugins/
-  NodeName: "{{ ansible_fqdn }}"
-  ZoneName: NodeName
-  TicketSalt: ''

--- a/roles/icinga2/vars/Suse.yml
+++ b/roles/icinga2/vars/Suse.yml
@@ -2,15 +2,3 @@
 icinga2_packages_dependencies: ["libboost_regex1_66_0"]
 icinga2_user: icinga
 icinga2_group: icinga
-icinga2_config_path: /etc/icinga2
-icinga2_log_path: /var/log/icinga2
-icinga2_ca_path: /var/lib/icinga2/ca
-icinga2_cert_path: /var/lib/icinga2/certs
-icinga2_fragments_path: /var/tmp/icinga
-icinga2_default_constants:
-  PluginDir: /usr/lib/nagios/plugins/
-  ManubulonPluginDir: /usr/lib/nagios/plugins/
-  PluginContribDir: /usr/lib/nagios/plugins/
-  NodeName: "{{ ansible_fqdn }}"
-  ZoneName: NodeName
-  TicketSalt: ''

--- a/roles/icinga2/vars/main.yml
+++ b/roles/icinga2/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-icinga2_reserved:
+__icinga2_reserved:
   - Acknowledgement
   - ApiBindHost
   - ApiBindPort
@@ -67,12 +67,13 @@ icinga2_reserved:
   - ZonesDir
   - Dictionary
   - ConfigDir
-icinga2_feature_realname:
+__icinga2_feature_realname:
   idomysql: ido-mysql
   ido-mysql: idomysql
   ido-pgsql: idopgsql
   idopgsql: ido-pgsql
-icinga2_object_types:
+# constant defined for the icinga2_object action module
+__icinga2_object_types:
   - ApiListener
   - ApiUser
   - CheckCommand
@@ -108,3 +109,10 @@ icinga2_object_types:
   - User
   - UserGroup
   - Zone
+__icinga2_default_constants:
+  PluginDir: /usr/lib/nagios/plugins/
+  ManubulonPluginDir: /usr/lib/nagios/plugins/
+  PluginContribDir: /usr/lib/nagios/plugins/
+  NodeName: "{{ ansible_fqdn }}"
+  ZoneName: NodeName
+  TicketSalt: ''


### PR DESCRIPTION
Hi icinga team, 
I've been trying to trouble a deployment issue (only on my side) and ended up looking at your collection.
I found some improvments to be performed, so i took the freedom to give it a try.
Here you find my proposal.

In a nutshell, i have : 
- moved all modules call to fqdn
- prefixed internal variables with `__icinga2` to reduce its exposure to extern variable or any unwanted superseed
- implemented the argument_specs for role variable validation
- done some linting
- rearranged the defaults/vars where applicable.

I carefully bear attention to not touch the business logic being executed.

Also, this would be the 1st stone to build automated documentation for `antsibull` and `ansible-doc`.

So far, i've done it only on the icinga2 role. 
If this suits you, i could do further on the remaining roles.

Let me know your thoughts.