### PR TITLE
Fix bug with current beta release of Ansible Core

### DIFF
--- a/changelogs/fragments/fix_issue_372.yml
+++ b/changelogs/fragments/fix_issue_372.yml
@@ -1,0 +1,6 @@
+---
+
+bugfixes:
+  - Fix bug with current beta release of Ansible Core where ``XY is dict`` does not work for dictionary-like variables.
+    Use ``isinstance(XY, dict)`` now instead.
+    This bug is related to the ``prefix`` filter plugin but might arise again with other parts of the code in the future.

--- a/plugins/filter/prefix.py
+++ b/plugins/filter/prefix.py
@@ -5,12 +5,12 @@ __metaclass__ = type
 
 
 def prefix(d, prefix):
-    if type(d) is dict:
+    if isinstance(d, dict):
         ret = {}
         for key in d.keys():
             ret[prefix + key] = d[key]
         return ret
-    elif type(d) is list:
+    elif isinstance(d, list):
         ret = []
         for item in d:
             ret.append(prefix + item)


### PR DESCRIPTION
Testing for 'if type(var) is XY' is not sufficient anymore since the actual type can now be something like '_AnsibleLazyTemplateDict'.

Changed in favor of 'if isinstance(var, XY)'.

Fixes #372