### PR TITLE
Fix exposure of TicketSalt on Satellites / Agents

### DIFF
--- a/changelogs/fragments/fix_issue_371.yml
+++ b/changelogs/fragments/fix_issue_371.yml
@@ -1,0 +1,5 @@
+---
+
+bugfixes:
+  - Fix exposure of secret ``TicketSalt`` inside the API feature.
+    Use constant ``TicketSalt`` as the value for ``ticket_salt`` instead which is an empty string if unchanged by the user.

--- a/roles/icinga2/tasks/features/api.yml
+++ b/roles/icinga2/tasks/features/api.yml
@@ -22,7 +22,7 @@
 - name: api feature cleanup arguments list
   set_fact:
     args: "{{ args|default({}) | combine({idx.key: idx.value}) }}"
-  when: idx.key not in ['ca_host', 'ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert' ]
+  when: idx.key not in ['ca_host', 'ca_host_port', 'cert_name', 'ca_fingerprint', 'force_newcert', 'zones', 'endpoints', 'ssl_cacert', 'ssl_key', 'ssl_cert', 'ticket_salt' ]
   loop: "{{ icinga2_dict_features.api |dict2items }}"
   loop_control:
     loop_var: idx


### PR DESCRIPTION
The 'ticket_salt' in the API feature is now using the constant 'TicketSalt' as its value. This avoids accidental exposure as the actual secret is kept on a per host basis using constants. The default for the constant 'TicketSalt' is just an empty string if unchanged by the user.

Fixes #371