### PR TITLE
Add port to Icinga Web's own database connection

### DIFF
--- a/changelogs/fragments/fix_issue_367.yml
+++ b/changelogs/fragments/fix_issue_367.yml
@@ -1,0 +1,4 @@
+---
+
+bugfixes:
+  - Fix bug where the port for Icinga Web's own database connection was not set in ``resources.ini``.

--- a/roles/icingaweb2/tasks/manage_icingaweb_config.yml
+++ b/roles/icingaweb2/tasks/manage_icingaweb_config.yml
@@ -54,6 +54,7 @@
         type: db
         db: "{{ icingaweb2_db['type'] | default('mysql') }}"
         host: "{{ icingaweb2_db['host'] }}"
+        port: "{{ icingaweb2_db['port'] | default(omit) }}"
         dbname: "{{ icingaweb2_db['name'] }}"
         username: "{{ icingaweb2_db['user'] }}"
         password: "{{ icingaweb2_db['password'] }}"


### PR DESCRIPTION
The port for Icinga Web's database connection is no properly set inside of 'resources.ini'.

Fixes #367