### PR TITLE
Fix template to properly quote numeric values

### DIFF
--- a/changelogs/fragments/fix_issue_285.yml
+++ b/changelogs/fragments/fix_issue_285.yml
@@ -1,0 +1,4 @@
+---
+
+bugfixes:
+  - Fix templating issue where explicitly quoting integer values for use as strings is necessary in certain versions of e.g. Jinja2 - thanks @sol1-matt

--- a/roles/icingaweb2/templates/ini_template.j2
+++ b/roles/icingaweb2/templates/ini_template.j2
@@ -4,7 +4,7 @@
 [{{ section }}]
 {% for option, value in options.items() %}
 {% if value is number %}
-{{ option }} = "{{ value }}"
+{{ option }} = "{{ value | quote }}"
 {% elif value is iterable and (value is not string and value is not mapping) %}
 {{ option }} = "{{ value | join(', ') }}"
 {% elif ( value is string and ( "=" in value or "!" in value or " " in value ) )%}


### PR DESCRIPTION
Explicitly quote numeric values in 'ini_template.j2' to ensure compatibilty with certain versions of Jinja2.

Fixes #285